### PR TITLE
Add support for list literals

### DIFF
--- a/samples/in/Lists.tye
+++ b/samples/in/Lists.tye
@@ -1,0 +1,10 @@
+typesystem Lists
+
+  rule One infers 1 : one
+
+  rule Two infers 2 : two
+
+  rule EmptyList infers [ ] : list
+
+  rule NonEmptyList infers [ e1 ] : list
+    if e1 : t1

--- a/samples/in/Lists.tye
+++ b/samples/in/Lists.tye
@@ -6,7 +6,7 @@ typesystem Lists
 
   rule EmptyList infers [ ] : list
 
-  rule NonEmptyList infers [ e1, e2, e3 ] : list
-    if e1 : t1
-    and e2: t2
-    and e3: t3
+  rule NonEmptyList infers [ e1, e2 | r ] : list
+    if e1 : t
+    and e2 : t
+    and r : list

--- a/samples/in/Lists.tye
+++ b/samples/in/Lists.tye
@@ -6,5 +6,7 @@ typesystem Lists
 
   rule EmptyList infers [ ] : list
 
-  rule NonEmptyList infers [ e1 ] : list
+  rule NonEmptyList infers [ e1, e2, e3 ] : list
     if e1 : t1
+    and e2: t2
+    and e3: t3

--- a/samples/out/new/src/ListsTypeSystem.scala
+++ b/samples/out/new/src/ListsTypeSystem.scala
@@ -20,9 +20,15 @@ class ListsTypeSystem extends TypeSystem[LExpression]:
         TypeError.noTypeFor(exp)
 
     case LList(e1, e2) => 
-      if e2 == LNil then
+      if e2.isInstanceOf[LList[Type]] then
         for
           _ <- typecheck(e1, env)
+          LList(e3, eb) = e2
+          _ <- typecheck(e3, env)
+          _ <- eb.expecting[LList[Type]]
+          LList(e4, eb2) = eb
+          _ <- typecheck(e4, env)
+          _ <- checkIf(eb2 == LNil, TypeError.noTypeFor(eb2))
         yield
           Type.List
       else

--- a/samples/out/new/src/ListsTypeSystem.scala
+++ b/samples/out/new/src/ListsTypeSystem.scala
@@ -1,0 +1,32 @@
+import tyes.runtime.*
+import example.*
+
+class ListsTypeSystem extends TypeSystem[LExpression]:
+  type T = Type
+
+  enum Type extends tyes.runtime.Type:
+    case List
+    case One
+    case Two
+
+  def typecheck(exp: LExpression[Type], env: Environment[Type]): Either[String, Type] = exp match {
+    case LNil => Right(Type.List)
+    case LNumber(n) => 
+      if n == 1 then
+        Right(Type.One)
+      else if n == 2 then
+        Right(Type.Two)
+      else
+        TypeError.noTypeFor(exp)
+
+    case LList(e1, e2) => 
+      if e2 == LNil then
+        for
+          _ <- typecheck(e1, env)
+        yield
+          Type.List
+      else
+        TypeError.noTypeFor(exp)
+
+    case _ => TypeError.noTypeFor(exp)
+  }

--- a/samples/out/new/src/ListsTypeSystem.scala
+++ b/samples/out/new/src/ListsTypeSystem.scala
@@ -22,13 +22,10 @@ class ListsTypeSystem extends TypeSystem[LExpression]:
     case LList(e1, e2) => 
       if e2.isInstanceOf[LList[Type]] then
         for
-          _ <- typecheck(e1, env)
-          LList(e3, eb) = e2
-          _ <- typecheck(e3, env)
-          _ <- eb.expecting[LList[Type]]
-          LList(e4, eb2) = eb
-          _ <- typecheck(e4, env)
-          _ <- checkIf(eb2 == LNil, TypeError.noTypeFor(eb2))
+          t <- typecheck(e1, env)
+          LList(e3, r) = e2
+          _ <- typecheck(e3, env).expecting(t)
+          _ <- typecheck(r, env).expecting(Type.List)
         yield
           Type.List
       else

--- a/src/main/scala/example/LExpressionLanguage.scala
+++ b/src/main/scala/example/LExpressionLanguage.scala
@@ -7,3 +7,5 @@ case class LPlus[TType](left: LExpression[TType], right: LExpression[TType]) ext
 case class LLet[TType](varName: String, varType: Option[TType], varExp: LExpression[TType], inExp: LExpression[TType]) extends LExpression[TType]
 case class LFun[TType](argName: String, argType: Option[TType], bodyExp: LExpression[TType]) extends LExpression[TType]
 case class LApp[TType](funExp: LExpression[TType], argExp: LExpression[TType]) extends LExpression[TType]
+case object LNil extends LExpression[Nothing]
+case class LList[TType](head: LExpression[TType], tail: LExpression[TType]) extends LExpression[TType]

--- a/src/main/scala/example/LExpressionParser.scala
+++ b/src/main/scala/example/LExpressionParser.scala
@@ -12,7 +12,11 @@ class LExpressionParser[TType] extends RegexParsers:
 
   def number = ("0" | raw"[1-9]\d*".r) ^^ { numStr => LNumber(numStr.toInt) }
   
-  def leaf = ("(" ~> expression <~ ")") | number | variable 
+  def list = "[" ~> repsep(expression, ",") <~ "]" ^^ {
+    elems => elems.foldRight(LNil: LExpression[TType]) { (e, l) => LList(e, l) }
+  }
+
+  def leaf = ("(" ~> expression <~ ")") | number | variable | list
 
   def app = leaf ~ leaf.* ^^ {
     case exp ~ rs => rs.foldLeft(exp) { (left, right) => LApp(left, right) }

--- a/src/main/scala/tyes/cli/CommandLine.scala
+++ b/src/main/scala/tyes/cli/CommandLine.scala
@@ -136,12 +136,15 @@ object CommandLine:
       val expParser = LExpressionWithModelTypesParser(tsDecl.types)
       runInteractive(line => {
         for exp <- parseLExpression(line, expParser) do
-          TyesInterpreter.typecheck(tsDecl, exp) match {
-            case Some(typ) if typ.isGround => 
-              println(expParser.prettyPrint(typ))
-            case _ => 
-              Console.err.println("No type for expression")
-          }
+          try
+            TyesInterpreter.typecheck(tsDecl, exp) match {
+              case Some(typ) if typ.isGround => 
+                println(expParser.prettyPrint(typ))
+              case _ => 
+                Console.err.println("No type for expression")
+            }
+          catch case e =>
+            e.printStackTrace()
         },
         expSrcOption)
 

--- a/src/main/scala/tyes/cli/LExpressionContextParser.scala
+++ b/src/main/scala/tyes/cli/LExpressionContextParser.scala
@@ -24,11 +24,16 @@ class LExpressionContextParser(bindings: TyesTermLanguageBindings):
   )
 
   def number = ("0" | raw"[1-9]\d*".r) ^^ { numStr => Term.Function("LNumber", Term.Constant(numStr.toInt)) }
+
+  def list = "[" ~> repsep(expression, ",") <~ "]" ^^ {
+    elems => elems.foldRight(Term.Function("LNil")) { (e, l) => Term.Function("LList", e, l) }
+  }
   
   def leaf = 
     ("(" ~> expression <~ ")") 
     | number 
     | variable
+    | list
 
   def app = leaf ~ leaf.* ^^ {
     case exp ~ rs => rs.foldLeft(exp) { (left, right) => Term.Function("LApp", left, right) }

--- a/src/main/scala/tyes/cli/LExpressionExtensions.scala
+++ b/src/main/scala/tyes/cli/LExpressionExtensions.scala
@@ -27,4 +27,6 @@ object LExpressionExtensions:
             bodyExp.convert
           )
         case LApp(funExp, argExp) => Term.Function("LApp", funExp.convert, argExp.convert)
+        case LNil => Term.Function("LNil")
+        case LList(head, tail) => Term.Function("LList", head.convert, tail.convert)
     }

--- a/src/main/scala/tyes/compiler/RuleIRGenerator.scala
+++ b/src/main/scala/tyes/compiler/RuleIRGenerator.scala
@@ -87,20 +87,11 @@ class RuleIRGenerator(
     val constructor = extractTemplate(term)
     val constructorReqs = constructor.matches(term)
       .get
-      .filter((_, v) => v.isGround || v.isInstanceOf[Term.Function])
       .toSeq
       .sortBy((k, v) => k) // TODO: ideally should sort in order of occurrence ltr
-
-    for (k, v) <- constructorReqs
-    yield
-      if v.isGround then 
-        IRCond.TermEquals(TCN.Var(k), termIRGenerator.generate(v))
-      else
-        val Term.Function(name, args*) = v
-        // TODO: get target type information for now using a heuristic
-        val typeParams = if args.length >= 1 then Seq(typeIRGenerator.typeEnumTypeRef) else Seq()
-        IRCond.OfType(TCN.Var(k), TCTypeRef(name, typeParams*))
-
+    
+    genRequiredConds(constructorReqs)
+    
   private def genConclusionConds(concl: Judgement, codeEnv: TargetCodeEnv): Seq[IRCond] =
     val HasType(cTerm, _) = concl.assertion
     
@@ -115,7 +106,7 @@ class RuleIRGenerator(
       .collect({ case (k, Term.Type(typ)) => k -> typ })
       .toMap
     
-    val destructureConds = genConclusionDestructureConds(termSubst, codeEnv)
+    val destructureConds = genDestructureConds(termSubst, codeEnv)
     val typeConds = genConclusionTypeConds(constructor.types.toSeq, typeSubst, codeEnv)
     destructureConds ++ typeConds
 
@@ -143,11 +134,24 @@ class RuleIRGenerator(
     yield
       c   
   
-  def genConclusionDestructureConds(termSubst: Map[String, Term], codeEnv: TargetCodeEnv): Seq[IRCond] =
+  def genRequiredConds(requirements: Seq[(String, Term)]): Seq[IRCond] =
+    for (k, v) <- requirements
+    if v.isGround || v.isInstanceOf[Term.Function]
+    yield
+      if v.isGround then 
+        IRCond.TermEquals(TCN.Var(k), termIRGenerator.generate(v))
+      else
+        val Term.Function(name, args*) = v
+        // TODO: get target type information for now using a heuristic
+        val typeParams = if args.length > 1 then Seq(typeIRGenerator.typeEnumTypeRef) else Seq()
+        IRCond.OfType(TCN.Var(k), TCTypeRef(name, typeParams*))
+
+  def genDestructureConds(termSubst: Map[String, Term], codeEnv: TargetCodeEnv): Seq[IRCond] =
+    val res = collection.mutable.Buffer[IRCond]()
     for
       case (k, f: Term.Function) <- termSubst.toSeq
       if !f.isGround
-    yield
+    do
       // Map all args into fresh variables
       val argsAsTemplate = f.args.zipWithIndex.map({
         case (v: Term.Variable, _) => v
@@ -159,15 +163,21 @@ class RuleIRGenerator(
         idCode
       )
       val declTermArgs = argsAsCode.map(vCode => Term.Variable(vCode.name): Term.Variable)
-      
+
       // Generate a composite term pattern with the fresh args and use it for
       // the destructuring declaration.
-      val declTerm = Term.Function(f.name, declTermArgs*)
+      val declTerm = Term.Function(f.name, declTermArgs*): Term.Function
       
-      IRCond.TypeDecl(
+      res += IRCond.TypeDecl(
         declPat = termIRGenerator.generatePattern(declTerm),
         typExp = IRNode.Type(IRType.FromCode(TCN.Var(k)))
       )
+
+      for subst <- declTerm.matches(f) do
+        res ++= genRequiredConds(subst.toSeq)
+        res ++= genDestructureConds(subst, codeEnv)
+      
+    return res.toSeq
 
   private def genPremiseConds(premise: Judgement, idx: Int, codeEnv: TargetCodeEnv): Seq[IRCond] =
     val HasType(pTerm, pType) = premise.assertion

--- a/src/main/scala/tyes/compiler/RuleIRGenerator.scala
+++ b/src/main/scala/tyes/compiler/RuleIRGenerator.scala
@@ -96,8 +96,10 @@ class RuleIRGenerator(
       if v.isGround then 
         IRCond.TermEquals(TCN.Var(k), termIRGenerator.generate(v))
       else
-        val Term.Function(name, _*) = v
-        IRCond.OfType(TCN.Var(k), TCTypeRef(name))
+        val Term.Function(name, args*) = v
+        // TODO: get target type information for now using a heuristic
+        val typeParams = if args.length >= 1 then Seq(typeIRGenerator.typeEnumTypeRef) else Seq()
+        IRCond.OfType(TCN.Var(k), TCTypeRef(name, typeParams*))
 
   private def genConclusionConds(concl: Judgement, codeEnv: TargetCodeEnv): Seq[IRCond] =
     val HasType(cTerm, _) = concl.assertion

--- a/src/main/scala/tyes/compiler/ir/TargetCodeIRGeneratorImpl.scala
+++ b/src/main/scala/tyes/compiler/ir/TargetCodeIRGeneratorImpl.scala
@@ -104,6 +104,18 @@ class TargetCodeIRGeneratorImpl(
         RuntimeAPIGenerator.genExpecting(t1Code, t2Code)
       )
 
+    case IRCond.TermEquals(t1Code, t2Code) =>
+      TCFC.Iterate(
+        TCP.Any,
+        RuntimeAPIGenerator.genCheck(TCN.Equals(t1Code, t2Code), IRError.NoType(t1Code))
+      )
+
+    case IRCond.OfType(termCode, typRef) =>
+      TCFC.Iterate(
+        TCP.Any,
+        RuntimeAPIGenerator.genExpecting(termCode, typRef)
+      )
+
     case IRCond.TypeDecl(declPat, typExp, None) if !canFail(typExp) =>
       TCFC.Let(declPat, generate(typExp, eitherIsExpected = false))
       
@@ -116,7 +128,7 @@ class TargetCodeIRGeneratorImpl(
           case Some(irExpect) => genExpectationCheck(typExpCode, irExpect)
         }
       )
-
+  
   }
 
   private def genExpectationCheck(

--- a/src/main/scala/tyes/compiler/ir/rewrite/NonInductionCondsToSwitchRewrite.scala
+++ b/src/main/scala/tyes/compiler/ir/rewrite/NonInductionCondsToSwitchRewrite.scala
@@ -37,6 +37,7 @@ object NonInductionCondsToSwitchRewrite extends Rewrite[IRNode]:
   private def condToError(cond: IRCond): IRError = cond match {
     case IRCond.EnvSizeIs(envVar, size) => IRError.UnexpectedEnvSize(TCN.Var(envVar), size)
     case IRCond.TypeEquals(t1Code, t2Code) => IRError.UnexpectedType(t1Code, t2Code)
+    case IRCond.TermEquals(t1Code, _) => IRError.NoType(t1Code)
     case IRCond.TypeDecl(_, IRNode.Type(irTyp), Some(IRTypeExpect.EqualsTo(expectedTypeCode))) =>
       val typCode = irTyp match {
         case IRType.FromCode(typCode, false) => typCode

--- a/src/main/scala/tyes/compiler/target/ScalaTargetCodeGenerator.scala
+++ b/src/main/scala/tyes/compiler/target/ScalaTargetCodeGenerator.scala
@@ -213,7 +213,7 @@ class ScalaTargetCodeGenerator extends TargetCodeGenerator:
     case TCP.Var(name) => name
     case TCP.WithType(pat, typeRef) => s"${generate(pat)}: ${generate(typeRef)}"
     case TCP.ADTConstructor(typeRef, args*) =>
-      args
+      generate(typeRef) + args
         .map(generate)
-        .mkString(generate(typeRef) + "(", ", ", ")")
+        .mkStringOrEmpty("(", ", ", ")")
   }

--- a/src/main/scala/tyes/compiler/target/TargetCodeNode.scala
+++ b/src/main/scala/tyes/compiler/target/TargetCodeNode.scala
@@ -28,7 +28,7 @@ enum TargetCodeNode:
   case Return(exp: TargetCodeNode)
   case ADTConstructorCall(typeRef: TargetCodeTypeRef, args: TargetCodeNode*)
 
-class TargetCodeTypeRef private(
+case class TargetCodeTypeRef private(
   val name: String, 
   val namespaces: Seq[String], 
   val params: Seq[TargetCodeTypeRef]

--- a/src/main/scala/tyes/runtime/TypeError.scala
+++ b/src/main/scala/tyes/runtime/TypeError.scala
@@ -21,9 +21,6 @@ object TypeError:
     val expectedType = expectedClass.getSimpleName
     generic(s"expected type $obtained to be a $expectedType instead")
 
-  def unexpectedTerm[E](obtained: E, expected: E) =
-    generic(s"expected term $obtained to be $expected instead")
-
   def unexpectedEnvSize[T <: Type](env: Environment[T], expectedSize: Int) =
     generic(s"expected environment with $expectedSize declarations, but found: $env")
 

--- a/src/main/scala/tyes/runtime/TypeError.scala
+++ b/src/main/scala/tyes/runtime/TypeError.scala
@@ -21,6 +21,9 @@ object TypeError:
     val expectedType = expectedClass.getSimpleName
     generic(s"expected type $obtained to be a $expectedType instead")
 
+  def unexpectedTerm[E](obtained: E, expected: E) =
+    generic(s"expected term $obtained to be $expected instead")
+
   def unexpectedEnvSize[T <: Type](env: Environment[T], expectedSize: Int) =
     generic(s"expected environment with $expectedSize declarations, but found: $env")
 


### PR DESCRIPTION
This PR adds support for list literals in the form of `[ e1, e2, ... ]` to the sample language, encoded as `LList(head, tail)` and `LNil()` terms for the metalanguage. Furthermore, the metalanguage supports literals of the form `[ e1, e2, ... | t ]` to allow matching the remaining tail in the typing rules.

Additionally it includes the implementation of some missing generic cases in the compiler that cover composite terms in rules (i.e. functions with functions as their arguments).