### PR TITLE
Add support for premise ranges

### DIFF
--- a/samples/in/LetVar_v2.tye
+++ b/samples/in/LetVar_v2.tye
@@ -1,0 +1,19 @@
+typesystem LetVarV2
+
+  rule infers 1 : one
+
+  rule infers 2 : two
+
+  rule Var
+    infers x : t under x : t
+
+  rule Plus
+    infers e_1 + e_2 : t
+    if e_1 : t
+    and ...
+    and e_n : t
+
+  rule Let
+    infers let x : t1 = e1 in e2 : t2
+    if e1 : t1
+    and e2 : t2 under x : t1

--- a/samples/in/PolymorphicSum_v2.tye
+++ b/samples/in/PolymorphicSum_v2.tye
@@ -1,0 +1,10 @@
+typesystem PolymorphicSumV2
+
+  rule One infers 1 : one
+
+  rule Two infers 2 : two
+
+  rule Sum infers e_1 + e_2 : t
+    if  e_1 : t
+    and ...
+    and e_n : t

--- a/samples/in/RegularCases_v2.tye
+++ b/samples/in/RegularCases_v2.tye
@@ -1,0 +1,8 @@
+typesystem RegularCases
+
+  rule One infers 1 : one
+
+  rule Sum infers e_1 + e_2 : one
+    if  e_1 : one
+    and ...
+    and e_n : one

--- a/samples/in/RegularCases_v2.tye
+++ b/samples/in/RegularCases_v2.tye
@@ -1,4 +1,4 @@
-typesystem RegularCases
+typesystem RegularCasesV2
 
   rule One infers 1 : one
 

--- a/samples/in/Sequence.tye
+++ b/samples/in/Sequence.tye
@@ -10,8 +10,7 @@ typesystem Sequence
 
   rule infers [ e_1, e_2, e_3 | l ] : t_1 -> t_2 -> t_3 -> t_l
     if e_1 : t_1
-    and
-    ...
+    and ...
     and e_n : t_n
     and l : t_l
 

--- a/samples/in/Sequence.tye
+++ b/samples/in/Sequence.tye
@@ -1,0 +1,22 @@
+typesystem Sequence
+
+  rule infers 1 : one
+  
+  rule infers 2 : two
+
+  rule infers [] : zero
+
+  rule infers x : t under x : t
+
+  rule infers [ e_1, e_2, e_3 | l ] : t_1 -> t_2 -> t_3 -> t_l
+    if e_1 : t_1
+    and
+    ...
+    and e_n : t_n
+    and l : t_l
+
+  rule infers let x_1 = e_0 in let x_2 = e_1 in let x_3 = e_2 in e_3 : t_3
+    if e_0 : t_0
+    and e_1 : t_1 under x_1 : t_0
+    and ...
+    and e_3 : t_3 under x_3 : t_0

--- a/samples/out/new/src/LetVarV2TypeSystem.scala
+++ b/samples/out/new/src/LetVarV2TypeSystem.scala
@@ -1,0 +1,43 @@
+import tyes.runtime.*
+import example.*
+
+class LetVarV2TypeSystem extends TypeSystem[LExpression]:
+  type T = Type
+
+  enum Type extends tyes.runtime.Type:
+    case One
+    case Two
+
+  def typecheck(exp: LExpression[Type], env: Environment[Type]): Either[String, Type] = exp match {
+    case LNumber(n) => 
+      if n == 1 then
+        Right(Type.One)
+      else if n == 2 then
+        Right(Type.Two)
+      else
+        TypeError.noTypeFor(exp)
+
+    case LVariable(x) => 
+      for
+        _ <- checkEnvSize(env, 1)
+        t <- env.get(x)
+      yield
+        t
+
+    case LPlus(e_1, e_2) => 
+      for
+        t <- typecheck(e_1, env)
+        _ <- typecheck(e_2, env).expecting(t)
+      yield
+        t
+
+    case LLet(x, _t1, e1, e2) => 
+      for
+        t1 <- checkTypeDeclared(_t1, exp)
+        _ <- typecheck(e1, env).expecting(t1)
+        t2 <- typecheck(e2, Environment(x -> t1))
+      yield
+        t2
+
+    case _ => TypeError.noTypeFor(exp)
+  }

--- a/samples/out/new/src/PolymorphicSumV2TypeSystem.scala
+++ b/samples/out/new/src/PolymorphicSumV2TypeSystem.scala
@@ -1,0 +1,28 @@
+import tyes.runtime.*
+import example.*
+
+class PolymorphicSumV2TypeSystem extends TypeSystem[LExpression]:
+  type T = Type
+
+  enum Type extends tyes.runtime.Type:
+    case One
+    case Two
+
+  def typecheck(exp: LExpression[Type], env: Environment[Type]): Either[String, Type] = exp match {
+    case LNumber(n) => 
+      if n == 1 then
+        Right(Type.One)
+      else if n == 2 then
+        Right(Type.Two)
+      else
+        TypeError.noTypeFor(exp)
+
+    case LPlus(e_1, e_2) => 
+      for
+        t <- typecheck(e_1, env)
+        _ <- typecheck(e_2, env).expecting(t)
+      yield
+        t
+
+    case _ => TypeError.noTypeFor(exp)
+  }

--- a/samples/out/new/src/RegularCasesV2TypeSystem.scala
+++ b/samples/out/new/src/RegularCasesV2TypeSystem.scala
@@ -1,0 +1,25 @@
+import tyes.runtime.*
+import example.*
+
+class RegularCasesV2TypeSystem extends TypeSystem[LExpression]:
+  type T = Type
+
+  enum Type extends tyes.runtime.Type:
+    case One
+
+  def typecheck(exp: LExpression[Type], env: Environment[Type]): Either[String, Type] = exp match {
+    case LNumber(n) => 
+      if n == 1 then
+        Right(Type.One)
+      else
+        TypeError.noTypeFor(exp)
+
+    case LPlus(e_1, e_2) => 
+      for
+        _ <- typecheck(e_1, env).expecting(Type.One)
+        _ <- typecheck(e_2, env).expecting(Type.One)
+      yield
+        Type.One
+
+    case _ => TypeError.noTypeFor(exp)
+  }

--- a/samples/out/new/src/SequenceTypeSystem.scala
+++ b/samples/out/new/src/SequenceTypeSystem.scala
@@ -1,0 +1,61 @@
+import tyes.runtime.*
+import example.*
+
+class SequenceTypeSystem extends TypeSystem[LExpression]:
+  type T = Type
+
+  enum Type extends tyes.runtime.Type:
+    case One
+    case Two
+    case Zero
+    case $FunType(t1: Type, t2: Type) extends Type, tyes.runtime.CompositeType(t1, t2)
+
+  def typecheck(exp: LExpression[Type], env: Environment[Type]): Either[String, Type] = exp match {
+    case LNil => Right(Type.Zero)
+    case LNumber(n) => 
+      if n == 1 then
+        Right(Type.One)
+      else if n == 2 then
+        Right(Type.Two)
+      else
+        TypeError.noTypeFor(exp)
+
+    case LVariable(x) => 
+      for
+        _ <- checkEnvSize(env, 1)
+        t <- env.get(x)
+      yield
+        t
+
+    case LList(e_1, e2) => 
+      if e2.isInstanceOf[LList[Type]] then
+        for
+          t_1 <- typecheck(e_1, env)
+          LList(e_2, eb) = e2
+          t_2 <- typecheck(e_2, env)
+          _ <- eb.expecting[LList[Type]]
+          LList(e_3, l) = eb
+          t_3 <- typecheck(e_3, env)
+          t_l <- typecheck(l, env)
+        yield
+          Type.$FunType(t_1, Type.$FunType(t_2, Type.$FunType(t_3, t_l)))
+      else
+        TypeError.noTypeFor(exp)
+
+    case LLet(x_1, _, e_0, e4) => 
+      if e4.isInstanceOf[LLet[Type]] then
+        for
+          t_0 <- typecheck(e_0, env)
+          LLet(x_2, _, e_1, ed) = e4
+          _ <- typecheck(e_1, Environment(x_1 -> t_0))
+          _ <- ed.expecting[LLet[Type]]
+          LLet(x_3, _, e_2, e_3) = ed
+          _ <- typecheck(e_2, Environment(x_2 -> t_0))
+          t_3 <- typecheck(e_3, Environment(x_3 -> t_0))
+        yield
+          t_3
+      else
+        TypeError.noTypeFor(exp)
+
+    case _ => TypeError.noTypeFor(exp)
+  }

--- a/src/main/scala/tyes/cli/CommandLine.scala
+++ b/src/main/scala/tyes/cli/CommandLine.scala
@@ -59,7 +59,7 @@ object CommandLine:
         case "old" => old.TyesCodeGenerator
         case "new" => new TyesCompilerImpl
       }
-      invokeCompiler(compiler, path, scalaDstDirPath, binDstDirPath)
+      invokeCompiler(compiler, path, scalaDstDirPath, binDstDirPath, options.skipValidation)
 
   def tyer(args: String*): Unit =
     val options = InterpreterOptions.parse(args) match {
@@ -118,10 +118,16 @@ object CommandLine:
             None
     }
 
-  private def invokeCompiler(compiler: TyesCompiler, srcPath: Path, scalaDstDirPath: Path, binDstDirPath: Path): Unit = 
+  private def invokeCompiler(
+    compiler: TyesCompiler,
+    srcPath: Path,
+    scalaDstDirPath: Path,
+    binDstDirPath: Path,
+    skipValidation: Boolean
+  ): Unit = 
     val srcContent = Files.readString(srcPath)
     
-    for tsDecl <- parseTypeSystem(srcContent, skipValidation = false) do
+    for tsDecl <- parseTypeSystem(srcContent, skipValidation) do
       println(s"\tGenerating scala sources...")
       val (dstFileName, generatedCode) = compiler.compile(tsDecl)
 

--- a/src/main/scala/tyes/cli/CommandLine.scala
+++ b/src/main/scala/tyes/cli/CommandLine.scala
@@ -139,12 +139,15 @@ object CommandLine:
       val expParser = LExpressionWithModelTypesParser(tsDecl.types)
       runInteractive(line => {
         for exp <- parseLExpression(line, expParser) do
-          TyesInterpreter.typecheck(tsDecl, exp) match {
-            case Some(typ) if typ.isGround => 
-              println(expParser.prettyPrint(typ))
-            case _ => 
-              Console.err.println("No type for expression")
-          }
+          try
+            TyesInterpreter.typecheck(tsDecl, exp) match {
+              case Some(typ) if typ.isGround => 
+                println(expParser.prettyPrint(typ))
+              case _ => 
+                Console.err.println("No type for expression")
+            }
+          catch case e =>
+            e.printStackTrace()
         },
         expSrcOption)
 

--- a/src/main/scala/tyes/cli/CompilerOptions.scala
+++ b/src/main/scala/tyes/cli/CompilerOptions.scala
@@ -3,7 +3,8 @@ package tyes.cli
 case class CompilerOptions(
   srcFilePaths: Seq[String],
   targetDirPath: Option[String],
-  versionId: Option[String]
+  versionId: Option[String],
+  skipValidation: Boolean = false
 )
 
 object CompilerOptions extends OptionsParser[CompilerOptions]:
@@ -11,10 +12,10 @@ object CompilerOptions extends OptionsParser[CompilerOptions]:
 
   protected override def commandName = "tyec"
 
-  protected override def optionsSyntaxDocs = "[-out <targetDirPath>] [-version <versionId>] <srcFilePaths...>"
+  protected override def optionsSyntaxDocs = "[-out <targetDirPath>] [-skipValidation] [-version <versionId>] <srcFilePaths...>"
   
-  protected override def options = outputDirOption.? ~ versionOption.? ~ sourceFiles ^^ {
-    case targetPath ~ versionId ~ srcPaths => CompilerOptions(srcPaths, targetPath, versionId)
+  protected override def options = outputDirOption.? ~ skipValidationOption ~ versionOption.? ~ sourceFiles ^^ {
+    case targetPath ~ skipValidation ~ versionId ~ srcPaths => CompilerOptions(srcPaths, targetPath, versionId, skipValidation)
   }
 
   private def outputDirOption = "-out" ~>! anyNonFlag.withFailureMessage("no output directory specified")
@@ -22,3 +23,8 @@ object CompilerOptions extends OptionsParser[CompilerOptions]:
   private def versionOption = "-version" ~>! anyNonFlag.withFailureMessage("no version specified")
 
   private def sourceFiles = anyNonFlag.+.withFailureMessage("no source file(s) specified")
+
+  private def skipValidationOption = "-skipValidation".? ^^ {
+    case None => false
+    case Some(_) => true
+  }

--- a/src/main/scala/tyes/cli/InterpreterOptions.scala
+++ b/src/main/scala/tyes/cli/InterpreterOptions.scala
@@ -3,7 +3,8 @@ package tyes.cli
 case class InterpreterOptions(
   srcFilePath: String,
   versionId: Option[String],
-  expression: Option[String]
+  expression: Option[String],
+  skipValidation: Boolean = false
 )
 
 object InterpreterOptions extends OptionsParser[InterpreterOptions]:
@@ -11,10 +12,10 @@ object InterpreterOptions extends OptionsParser[InterpreterOptions]:
 
   protected override def commandName = "tyer"
 
-  protected override def optionsSyntaxDocs = "<srcFilePath> [-version <versionId>] [-e <expression>]"
+  protected override def optionsSyntaxDocs = "<srcFilePath> [-skipValidation] [-version <versionId>] [-e <expression>]"
 
-  protected override def options = sourceFile ~ versionOption.? ~ expressionOption.? ^^ { 
-    case srcPath ~ versionOpt ~ exprOpt => InterpreterOptions(srcPath, versionOpt, exprOpt)
+  protected override def options = sourceFile ~ skipValidationOption ~ versionOption.? ~ expressionOption.? ^^ { 
+    case srcPath ~ skipValidation ~ versionOpt ~ exprOpt => InterpreterOptions(srcPath, versionOpt, exprOpt, skipValidation)
   }
 
   private def expressionOption = "-e" ~>! anyNonFlag.+.withFailureMessage("no expression specified") ^^ {
@@ -24,3 +25,8 @@ object InterpreterOptions extends OptionsParser[InterpreterOptions]:
   private def sourceFile = anyNonFlag.withFailureMessage("no source file specified")
 
   private def versionOption = "-version" ~>! anyNonFlag.withFailureMessage("no version specified")
+
+  private def skipValidationOption = "-skipValidation".? ^^ {
+    case None => false
+    case Some(_) => true
+  }

--- a/src/main/scala/tyes/cli/OptionsParser.scala
+++ b/src/main/scala/tyes/cli/OptionsParser.scala
@@ -16,9 +16,10 @@ trait OptionsParser[T]:
   
   protected def options: ArgParsers.Parser[T]
 
-  def parse(args: Seq[String]): Either[String, T] = 
-    if args.isEmpty then
+  def parse(args: Seq[String]): Either[String, T] =
+    val nonEmptyArgs = args.filter(_.nonEmpty)
+    if nonEmptyArgs.isEmpty then
       return Left(s"Syntax: ${commandName} ${optionsSyntaxDocs}")
 
-    ArgParsers.parse(ArgParsers.phrase(options), args)
+    ArgParsers.parse(ArgParsers.phrase(options), nonEmptyArgs)
       .withReadableError(prefix = commandName + " ")

--- a/src/main/scala/tyes/compiler/RuleIRGenerator.scala
+++ b/src/main/scala/tyes/compiler/RuleIRGenerator.scala
@@ -188,20 +188,18 @@ class RuleIRGenerator(
       ))
       typeIRGenerator.generateDestructureDecl(pType, codeEnv, inductionCall)
     case JudgementRange(from, to) =>
-      val Judgement(fromEnv, HasType(Term.Variable(fromVar), fromTyp)) = from: @unchecked
-      val Judgement(toEnv, HasType(Term.Variable(toVar), toTyp)) = to: @unchecked
-      assert(fromEnv == toEnv, "Both from and to premise must share the environment") // TODO: lift limitation
-      assert(fromTyp == toTyp, "Both from and to premise must share the judgement type") // TODO: lift limitation
+      val HasType(Term.Variable(fromVar), _) = from.assertion: @unchecked
+      val HasType(Term.Variable(toVar), _) = to.assertion: @unchecked
 
       val Some((fromIdent, fromIdxStr)) = extractIndex(fromVar): @unchecked
       val Some((toIdent, toIdxStr)) = extractIndex(toVar): @unchecked
       
       val fromIdx = fromIdxStr.toInt
       val toIdx = toIdxStr.toIntOption.getOrElse(Int.MaxValue)
-      for 
+      for
         i <- codeEnv.getIndexes(fromIdent).toSeq.sorted
         if i >= fromIdx && i <= toIdx
-        c <- genPremiseConds(Judgement(fromEnv, HasType(Term.Variable(s"${fromIdent}_$i"), fromTyp)), idx, codeEnv)
+        c <- genPremiseConds(from.replaceIndex(fromIdxStr, i.toString), idx, codeEnv)
       yield
         c 
   }

--- a/src/main/scala/tyes/compiler/RuleIRGenerator.scala
+++ b/src/main/scala/tyes/compiler/RuleIRGenerator.scala
@@ -188,18 +188,11 @@ class RuleIRGenerator(
       ))
       typeIRGenerator.generateDestructureDecl(pType, codeEnv, inductionCall)
     case JudgementRange(from, to) =>
-      val HasType(Term.Variable(fromVar), _) = from.assertion: @unchecked
-      val HasType(Term.Variable(toVar), _) = to.assertion: @unchecked
-
-      val Some((fromIdent, fromIdxStr)) = extractIndex(fromVar): @unchecked
-      val Some((toIdent, toIdxStr)) = extractIndex(toVar): @unchecked
-      
-      val fromIdx = fromIdxStr.toInt
-      val toIdx = toIdxStr.toIntOption.getOrElse(Int.MaxValue)
+      val (rangedVarName, idxRange) = extractRangeVariable(from, to)
       for
-        i <- codeEnv.getIndexes(fromIdent).toSeq.sorted
-        if i >= fromIdx && i <= toIdx
-        c <- genPremiseConds(from.replaceIndex(fromIdxStr, i.toString), idx, codeEnv)
+        i <- codeEnv.getIndexes(rangedVarName).toSeq.sorted
+        if idxRange.contains(i)
+        c <- genPremiseConds(from.replaceIndex(idxRange.start.toString, i.toString), idx, codeEnv)
       yield
         c 
   }

--- a/src/main/scala/tyes/compiler/RuleIRGenerator.scala
+++ b/src/main/scala/tyes/compiler/RuleIRGenerator.scala
@@ -7,6 +7,7 @@ import tyes.compiler.ir.IRType
 import tyes.compiler.target.TargetCodeNode
 import tyes.compiler.target.TargetCodePattern
 import tyes.model.*
+import tyes.model.indexes.*
 import tyes.model.TyesLanguageExtensions.*
 import utils.collections.*
 
@@ -187,14 +188,13 @@ class RuleIRGenerator(
       ))
       typeIRGenerator.generateDestructureDecl(pType, codeEnv, inductionCall)
     case JudgementRange(from, to) =>
-      val Judgement(fromEnv, HasType(Term.Variable(fromVar), fromTyp)) = from
-      val Judgement(toEnv, HasType(Term.Variable(toVar), toTyp)) = to
-      assert(fromEnv == toEnv, "Both from and to premise must share the environment")
-      assert(fromTyp == toTyp, "Both from and to premise must share the judgement type")
+      val Judgement(fromEnv, HasType(Term.Variable(fromVar), fromTyp)) = from: @unchecked
+      val Judgement(toEnv, HasType(Term.Variable(toVar), toTyp)) = to: @unchecked
+      assert(fromEnv == toEnv, "Both from and to premise must share the environment") // TODO: lift limitation
+      assert(fromTyp == toTyp, "Both from and to premise must share the judgement type") // TODO: lift limitation
 
-      val Array(fromIdent, fromIdxStr) = fromVar.split("_")
-      val Array(toIdent, toIdxStr) = toVar.split("_")
-      assert(fromIdent == toIdent, "Both from and to premise must share the judgement var minus index") // todo: generalize to matched terms?
+      val Some((fromIdent, fromIdxStr)) = extractIndex(fromVar): @unchecked
+      val Some((toIdent, toIdxStr)) = extractIndex(toVar): @unchecked
       
       val fromIdx = fromIdxStr.toInt
       val toIdx = toIdxStr.toIntOption.getOrElse(Int.MaxValue)

--- a/src/main/scala/tyes/compiler/TargetCodeEnv.scala
+++ b/src/main/scala/tyes/compiler/TargetCodeEnv.scala
@@ -1,6 +1,7 @@
 package tyes.compiler
 
 import tyes.model.*
+import tyes.model.indexes.*
 import tyes.model.terms.TermVariable
 import tyes.compiler.target.TargetCodeNode
 
@@ -65,8 +66,8 @@ class TargetCodeEnv(private val parent: Option[TargetCodeEnv] = None):
 
   def getIndexes(indexedName: String): Set[Int] =
     nameToIds.keys
-      .map(_.split("_", 2))
-      .collect({ case Array(name, idxStr) if name == indexedName && idxStr.matches(raw"\d+") => idxStr.toInt })
+      .map(extractIndex(_))
+      .collect({ case Some((name, idxStr)) if name == indexedName && idxStr.matches(raw"\d+") => idxStr.toInt })
       .toSet
       .union(parent.map(_.getIndexes(indexedName)).getOrElse(Set()))
 

--- a/src/main/scala/tyes/compiler/TargetCodeEnv.scala
+++ b/src/main/scala/tyes/compiler/TargetCodeEnv.scala
@@ -22,8 +22,6 @@ class TargetCodeEnv(private val parent: Option[TargetCodeEnv] = None):
   import TargetCodeEnv.*
   private val TCN = TargetCodeNode
 
-  private val DIGIT_REGEX = raw"(\d+)".r
-
   private val idToCode = scala.collection.mutable.Map[Id, TargetCodeNode]()
   private val nameToIds = scala.collection.mutable.Map[String, Seq[Id]]()
   
@@ -68,8 +66,8 @@ class TargetCodeEnv(private val parent: Option[TargetCodeEnv] = None):
 
   def getIndexes(indexedName: String): Set[Int] =
     nameToIds.keys
-      .map(extractIndex(_))
-      .collect({ case Some((`indexedName`, DIGIT_REGEX(idxStr))) => idxStr.toInt })
+      .map(extractIntIndex(_))
+      .collect({ case Some((`indexedName`, idx)) => idx })
       .toSet
       .union(parent.map(_.getIndexes(indexedName)).getOrElse(Set()))
 

--- a/src/main/scala/tyes/compiler/TargetCodeEnv.scala
+++ b/src/main/scala/tyes/compiler/TargetCodeEnv.scala
@@ -63,6 +63,13 @@ class TargetCodeEnv(private val parent: Option[TargetCodeEnv] = None):
 
   def contains(termVar: TermVariable): Boolean = getIds(termVar).isDefined
 
+  def getIndexes(indexedName: String): Set[Int] =
+    nameToIds.keys
+      .map(_.split("_", 2))
+      .collect({ case Array(name, idxStr) if name == indexedName && idxStr.matches(raw"\d+") => idxStr.toInt })
+      .toSet
+      .union(parent.map(_.getIndexes(indexedName)).getOrElse(Set()))
+
   override def toString(): String =
     val parentStr = parent.map(" <- " + _.toString).getOrElse("")
     val idToCodeStr = idToCode.mkString(", ")

--- a/src/main/scala/tyes/compiler/TargetCodeEnv.scala
+++ b/src/main/scala/tyes/compiler/TargetCodeEnv.scala
@@ -22,6 +22,8 @@ class TargetCodeEnv(private val parent: Option[TargetCodeEnv] = None):
   import TargetCodeEnv.*
   private val TCN = TargetCodeNode
 
+  private val DIGIT_REGEX = raw"(\d+)".r
+
   private val idToCode = scala.collection.mutable.Map[Id, TargetCodeNode]()
   private val nameToIds = scala.collection.mutable.Map[String, Seq[Id]]()
   
@@ -67,7 +69,7 @@ class TargetCodeEnv(private val parent: Option[TargetCodeEnv] = None):
   def getIndexes(indexedName: String): Set[Int] =
     nameToIds.keys
       .map(extractIndex(_))
-      .collect({ case Some((name, idxStr)) if name == indexedName && idxStr.matches(raw"\d+") => idxStr.toInt })
+      .collect({ case Some((`indexedName`, DIGIT_REGEX(idxStr))) => idxStr.toInt })
       .toSet
       .union(parent.map(_.getIndexes(indexedName)).getOrElse(Set()))
 

--- a/src/main/scala/tyes/compiler/TyesEnvDesugarer.scala
+++ b/src/main/scala/tyes/compiler/TyesEnvDesugarer.scala
@@ -23,10 +23,18 @@ class TyesEnvDesugarer(commonEnvVar: String):
       conclusion = desugar(concl, conclEnvVars.headOption)
     )
 
-  def desugar(judg: Judgement, envVarToReplace: Option[String]): Judgement =
-    judg.copy(
-      env = desugar(judg.env, envVarToReplace)
+  type PremiseMatch[P <: Premise] <: Premise = P match {
+    case Judgement => Judgement
+    case JudgementRange => JudgementRange
+  }
+
+  def desugar(prem: Premise, envVarToReplace: Option[String]): PremiseMatch[prem.type]  = prem match {
+    case judg: Judgement => judg.copy(env = desugar(judg.env, envVarToReplace))
+    case rng: JudgementRange => JudgementRange(
+      desugar(rng.from, envVarToReplace),
+      desugar(rng.to, envVarToReplace)
     )
+  }
 
   def desugar(env: Environment, envVarToReplace: Option[String]): Environment =
     if env.parts.isEmpty then

--- a/src/main/scala/tyes/compiler/TypeSystemIRGenerator.scala
+++ b/src/main/scala/tyes/compiler/TypeSystemIRGenerator.scala
@@ -124,6 +124,6 @@ class TypeSystemIRGenerator(
       if norGroupIdx == -1 then
         Seq(r) +: norGroups
       else
-        val (before, idxGroup +: after) = norGroups.splitAt(norGroupIdx)
+        val (before, idxGroup +: after) = norGroups.splitAt(norGroupIdx): @unchecked
         before ++ ((r +: idxGroup) +: after)
   }

--- a/src/main/scala/tyes/interpreter/TyesInterpreter.scala
+++ b/src/main/scala/tyes/interpreter/TyesInterpreter.scala
@@ -46,13 +46,40 @@ object TyesInterpreter:
             case (Some(typeVarEnv), JudgementRange(from, to)) =>
               val Judgement(fromEnv, HasType(Term.Variable(fromVar), fromTyp)) = from
               val Judgement(toEnv, HasType(Term.Variable(toVar), toTyp)) = to
-              assert(fromEnv == toEnv, "Both from and to premise must share the environment")
-              assert(fromTyp == toTyp, "Both from and to premise must share the judgement type")
 
               val Array(fromIdent, fromIdxStr) = fromVar.split("_")
               val Array(toIdent, toIdxStr) = toVar.split("_")
               assert(fromIdent == toIdent, "Both from and to premise must share the judgement var minus index") // todo: generalize to matched terms?
               
+              var typeVarsToReplace = getIndexedTypeVarsToReplace(fromTyp, toTyp, fromIdxStr, toIdxStr)
+              var termVarsToReplace = Set[String]()
+
+              fromEnv.parts.zip(toEnv.parts).foreach({
+                case (fv: EnvironmentPart.Variable, tv: EnvironmentPart.Variable) => assert(fv == tv)
+                case (EnvironmentPart.Bindings(fbs), EnvironmentPart.Bindings(tbs)) =>
+                  fbs.zip(tbs).foreach({
+                    case (Binding.BindName(fn, ft), Binding.BindName(tn, tt)) =>
+                      assert(fn == tn)
+                      typeVarsToReplace ++= getIndexedTypeVarsToReplace(ft, tt, fromIdxStr, toIdxStr)
+                    case (Binding.BindVariable(fv, ft), Binding.BindVariable(tv, tt)) =>
+                      val fTermVarArr = fv.split("_", 2)
+                      val tTermVarArr = tv.split("_", 2)
+                      assert(fTermVarArr.length == tTermVarArr.length, s"Both from and to premise matching vars must either have index or not: got ${fv} and ${tv}")
+                      assert(fTermVarArr(0) == tTermVarArr(0), s"Both from and to premise must share the same vars minus index: got ${fv} and ${tv}")
+            
+                      if fTermVarArr.length > 1 then
+                        assert(fTermVarArr.length == 2, s"Only one level of indexes supported: $fTermVarArr")
+                        if fTermVarArr(1) != tTermVarArr(1) then
+                          assert(fTermVarArr(1) == fromIdxStr, s"From premise var indexes must match term var indexes: got ${fTermVarArr(1)}, expected $fromIdxStr")
+                          assert(tTermVarArr(1) == toIdxStr, s"To premise var indexes must match term var indexes: got ${tTermVarArr(1)}, expected $toIdxStr")
+                          termVarsToReplace += fTermVarArr(0)
+
+                      typeVarsToReplace ++= getIndexedTypeVarsToReplace(ft, tt, fromIdxStr, toIdxStr)
+                    case _ => assert(false, "Both from and to premise environments must match minus var indexes")
+                  })
+                case _ => assert(false, "Both from and to premise environments must match minus var indexes")
+              })
+
               val fromIdx = fromIdxStr.toInt
               val toIdx = toIdxStr.toIntOption.getOrElse(Int.MaxValue)
               // Assumption all the variable indexes are bound in the conclusion
@@ -62,7 +89,18 @@ object TyesInterpreter:
                 currIdx = termVar.split("_")(1).toInt
                 if currIdx >= fromIdx && currIdx <= toIdx
               yield
-                Judgement(fromEnv, HasType(term, fromTyp))
+                val idxTypeVarSubst = typeVarsToReplace
+                  .map(n => s"${n}_${fromIdxStr}" -> Type.Variable(s"${n}_${currIdx}"))
+                  .toMap
+
+                val idxTermVarSubst = termVarsToReplace
+                  .map(n => s"${n}_${fromIdxStr}" -> s"${n}_${currIdx}")
+                  .toMap
+                
+                Judgement(
+                  fromEnv.remap(idxTermVarSubst).substitute(EnvironmentMatch(typeVarSubst = idxTypeVarSubst)),
+                  HasType(term, fromTyp.substitute(idxTypeVarSubst))
+                )
 
               premsToConsider.foldLeft(Option(typeVarEnv)) {
                 case (None, _) => None
@@ -76,6 +114,23 @@ object TyesInterpreter:
         }
       }
   }
+
+  private def getIndexedTypeVarsToReplace(fromTyp: Type, toTyp: Type, fromIdxStr: String, toIdxStr: String): Iterable[String] =
+    fromTyp.unifies(toTyp) match { 
+      case Some(subst) =>
+        for
+          (fTypeVarStr, Type.Variable(tTypeVarStr)) <- subst: @unchecked
+          fTypeVarArr = fTypeVarStr.split("_", 2)
+          tTypeVarArr = tTypeVarStr.split("_", 2)
+          _ = assert(fTypeVarArr.length == tTypeVarArr.length, s"Both from and to premise matching type vars must either have index or not: got ${fTypeVarStr} and ${tTypeVarStr}")
+          _ = assert(fTypeVarArr(0) == tTypeVarArr(0), s"Both from and to premise must share the same type vars minus index: got ${fTypeVarStr} and ${tTypeVarStr}")
+          if fTypeVarArr.length > 1
+        yield
+          assert(fTypeVarArr.length == 2, s"Only one level of indexes supported: $fTypeVarArr")
+          assert(fTypeVarArr(1) == fromIdxStr, s"From premise type var indexes must match term var indexes: got ${fTypeVarArr(1)}, expected $fromIdxStr")
+          assert(tTypeVarArr(1) == toIdxStr, s"To premise type var indexes must match term var indexes: got ${tTypeVarArr(1)}, expected $toIdxStr")
+          fTypeVarArr(0)
+    }
 
   def typecheck(
     tsDecl: TypeSystemDecl,

--- a/src/main/scala/tyes/interpreter/TyesInterpreter.scala
+++ b/src/main/scala/tyes/interpreter/TyesInterpreter.scala
@@ -16,6 +16,28 @@ object TyesInterpreter:
     then default
     else env
 
+  private def typecheckJudgement(
+    tsDecl: TypeSystemDecl,
+    judgement: Judgement,
+    premEnvMatch: EnvironmentMatch,
+    refinedMetaEnv: Environment,
+    allTermSubst: Map[String, Term]
+  ): Option[Map[String, Type]] =
+    val Judgement(premMetaEnv, HasType(premTerm, premTyp)) = judgement: @unchecked
+    
+    // replace the term and type variables we already know in the premise env and then produce an
+    // actual term env out of it
+    val premEnvOpt = getSelfOrDefaultIfEmpty(premMetaEnv, refinedMetaEnv).substitute(premEnvMatch).toConcrete
+
+    val refinedPremTerm = premTerm.substitute(allTermSubst)
+    val resTyp = premEnvOpt.flatMap(premEnv => typecheck(tsDecl, refinedPremTerm, premEnv))
+    for
+      resT <- resTyp
+      premTypeSubst <- premTyp.substitute(premEnvMatch.typeVarSubst).matches(resT)
+    yield
+      // if the premise expected type matched the obtained, update the type env with any new unifications
+      premEnvMatch.typeVarSubst ++ premTypeSubst
+
   def typecheck(tsDecl: TypeSystemDecl, ruleDecl: RuleDecl, term: Term, termEnv: Map[String, Type]): Option[Type] = ruleDecl.conclusion match {
     case Judgement(metaEnv, HasType(metaTerm, typ)) =>
       metaTerm.matches(term).flatMap { (termSubst) =>
@@ -43,31 +65,25 @@ object TyesInterpreter:
             // otherwise, check the next premise
             case (Some(typeVarEnv), judg: Judgement) =>
               val premEnvMatch = EnvironmentMatch(allVarSubst, typeVarEnv, envVarSubst)
-              typecheck(tsDecl, judg, premEnvMatch, refinedMetaEnv, allTermSubst)
+              typecheckJudgement(tsDecl, judg, premEnvMatch, refinedMetaEnv, allTermSubst)
             case (Some(typeVarEnv), JudgementRange(from, to)) =>
-              val HasType(Term.Variable(fromVar), _) = from.assertion: @unchecked
-              val HasType(Term.Variable(toVar), _) = to.assertion: @unchecked
+              val (rangedVarName, idxRange) = extractRangeVariable(from, to)
 
-              val Some((fromIdent, fromIdxStr)) = extractIndex(fromVar): @unchecked
-              val Some((toIdent, toIdxStr)) = extractIndex(toVar): @unchecked
-
-              val fromIdx = fromIdxStr.toInt
-              val toIdx = toIdxStr.toIntOption.getOrElse(Int.MaxValue)
               // Assume all the variable indexes are bound in the conclusion
               val premsToConsider = for
                 (termVar, term) <- allTermSubst
                 (termVarName, termVarIdx) <- extractIndex(termVar)
-                if termVarName == fromIdent
+                if termVarName == rangedVarName
                 currIdx = termVarIdx.toInt
-                if currIdx >= fromIdx && currIdx <= toIdx
+                if idxRange.contains(currIdx)
               yield
-                from.replaceIndex(fromIdx.toString, currIdx.toString)
+                from.replaceIndex(idxRange.start.toString, currIdx.toString)
 
               premsToConsider.foldLeft(Option(typeVarEnv)) {
                 case (None, _) => None
                 case (Some(pTypeVarEnv), judg) =>
                   val premEnvMatch = EnvironmentMatch(allVarSubst, pTypeVarEnv, envVarSubst)
-                  typecheck(tsDecl, judg, premEnvMatch, refinedMetaEnv, allTermSubst)
+                  typecheckJudgement(tsDecl, judg, premEnvMatch, refinedMetaEnv, allTermSubst)
               }
           }
 
@@ -75,28 +91,6 @@ object TyesInterpreter:
         }
       }
   }
-
-  def typecheck(
-    tsDecl: TypeSystemDecl,
-    judgement: Judgement,
-    premEnvMatch: EnvironmentMatch,
-    refinedMetaEnv: Environment,
-    allTermSubst: Map[String, Term]
-  ): Option[Map[String, Type]] =
-    val Judgement(premMetaEnv, HasType(premTerm, premTyp)) = judgement: @unchecked
-    
-    // replace the term and type variables we already know in the premise env and then produce an
-    // actual term env out of it
-    val premEnvOpt = getSelfOrDefaultIfEmpty(premMetaEnv, refinedMetaEnv).substitute(premEnvMatch).toConcrete
-
-    val refinedPremTerm = premTerm.substitute(allTermSubst)
-    val resTyp = premEnvOpt.flatMap(premEnv => typecheck(tsDecl, refinedPremTerm, premEnv))
-    for
-      resT <- resTyp
-      premTypeSubst <- premTyp.substitute(premEnvMatch.typeVarSubst).matches(resT)
-    yield
-      // if the premise expected type matched the obtained, update the type env with any new unifications
-      premEnvMatch.typeVarSubst ++ premTypeSubst
 
   def typecheck(tsDecl: TypeSystemDecl, term: Term, env: Map[String, Type]): Option[Type] =
     tsDecl

--- a/src/main/scala/tyes/interpreter/TyesInterpreter.scala
+++ b/src/main/scala/tyes/interpreter/TyesInterpreter.scala
@@ -2,6 +2,7 @@ package tyes.interpreter
 
 import scala.util.matching.Regex
 import tyes.model.*
+import tyes.model.indexes.*
 import tyes.model.TyesLanguageExtensions.*
 
 object TyesInterpreter:
@@ -44,63 +45,23 @@ object TyesInterpreter:
               val premEnvMatch = EnvironmentMatch(allVarSubst, typeVarEnv, envVarSubst)
               typecheck(tsDecl, judg, premEnvMatch, refinedMetaEnv, allTermSubst)
             case (Some(typeVarEnv), JudgementRange(from, to)) =>
-              val Judgement(fromEnv, HasType(Term.Variable(fromVar), fromTyp)) = from
-              val Judgement(toEnv, HasType(Term.Variable(toVar), toTyp)) = to
+              val Judgement(fromEnv, HasType(Term.Variable(fromVar), fromTyp)) = from: @unchecked
+              val Judgement(toEnv, HasType(Term.Variable(toVar), toTyp)) = to: @unchecked
 
-              val Array(fromIdent, fromIdxStr) = fromVar.split("_")
-              val Array(toIdent, toIdxStr) = toVar.split("_")
-              assert(fromIdent == toIdent, "Both from and to premise must share the judgement var minus index") // todo: generalize to matched terms?
-              
-              var typeVarsToReplace = getIndexedTypeVarsToReplace(fromTyp, toTyp, fromIdxStr, toIdxStr)
-              var termVarsToReplace = Set[String]()
-
-              fromEnv.parts.zip(toEnv.parts).foreach({
-                case (fv: EnvironmentPart.Variable, tv: EnvironmentPart.Variable) => assert(fv == tv)
-                case (EnvironmentPart.Bindings(fbs), EnvironmentPart.Bindings(tbs)) =>
-                  fbs.zip(tbs).foreach({
-                    case (Binding.BindName(fn, ft), Binding.BindName(tn, tt)) =>
-                      assert(fn == tn)
-                      typeVarsToReplace ++= getIndexedTypeVarsToReplace(ft, tt, fromIdxStr, toIdxStr)
-                    case (Binding.BindVariable(fv, ft), Binding.BindVariable(tv, tt)) =>
-                      val fTermVarArr = fv.split("_", 2)
-                      val tTermVarArr = tv.split("_", 2)
-                      assert(fTermVarArr.length == tTermVarArr.length, s"Both from and to premise matching vars must either have index or not: got ${fv} and ${tv}")
-                      assert(fTermVarArr(0) == tTermVarArr(0), s"Both from and to premise must share the same vars minus index: got ${fv} and ${tv}")
-            
-                      if fTermVarArr.length > 1 then
-                        assert(fTermVarArr.length == 2, s"Only one level of indexes supported: $fTermVarArr")
-                        if fTermVarArr(1) != tTermVarArr(1) then
-                          assert(fTermVarArr(1) == fromIdxStr, s"From premise var indexes must match term var indexes: got ${fTermVarArr(1)}, expected $fromIdxStr")
-                          assert(tTermVarArr(1) == toIdxStr, s"To premise var indexes must match term var indexes: got ${tTermVarArr(1)}, expected $toIdxStr")
-                          termVarsToReplace += fTermVarArr(0)
-
-                      typeVarsToReplace ++= getIndexedTypeVarsToReplace(ft, tt, fromIdxStr, toIdxStr)
-                    case _ => assert(false, "Both from and to premise environments must match minus var indexes")
-                  })
-                case _ => assert(false, "Both from and to premise environments must match minus var indexes")
-              })
+              val Some((fromIdent, fromIdxStr)) = extractIndex(fromVar): @unchecked
+              val Some((toIdent, toIdxStr)) = extractIndex(toVar): @unchecked
 
               val fromIdx = fromIdxStr.toInt
               val toIdx = toIdxStr.toIntOption.getOrElse(Int.MaxValue)
-              // Assumption all the variable indexes are bound in the conclusion
+              // Assume all the variable indexes are bound in the conclusion
               val premsToConsider = for
                 (termVar, term) <- allTermSubst
-                if termVar.matches(Regex.quote(fromIdent) + "_" + ".+")
-                currIdx = termVar.split("_")(1).toInt
+                (termVarName, termVarIdx) <- extractIndex(termVar)
+                if termVarName == fromIdent
+                currIdx = termVarIdx.toInt
                 if currIdx >= fromIdx && currIdx <= toIdx
               yield
-                val idxTypeVarSubst = typeVarsToReplace
-                  .map(n => s"${n}_${fromIdxStr}" -> Type.Variable(s"${n}_${currIdx}"))
-                  .toMap
-
-                val idxTermVarSubst = termVarsToReplace
-                  .map(n => s"${n}_${fromIdxStr}" -> s"${n}_${currIdx}")
-                  .toMap
-                
-                Judgement(
-                  fromEnv.remap(idxTermVarSubst).substitute(EnvironmentMatch(typeVarSubst = idxTypeVarSubst)),
-                  HasType(term, fromTyp.substitute(idxTypeVarSubst))
-                )
+                from.replaceIndex(fromIdx.toString, currIdx.toString)
 
               premsToConsider.foldLeft(Option(typeVarEnv)) {
                 case (None, _) => None
@@ -114,23 +75,6 @@ object TyesInterpreter:
         }
       }
   }
-
-  private def getIndexedTypeVarsToReplace(fromTyp: Type, toTyp: Type, fromIdxStr: String, toIdxStr: String): Iterable[String] =
-    fromTyp.unifies(toTyp) match { 
-      case Some(subst) =>
-        for
-          (fTypeVarStr, Type.Variable(tTypeVarStr)) <- subst: @unchecked
-          fTypeVarArr = fTypeVarStr.split("_", 2)
-          tTypeVarArr = tTypeVarStr.split("_", 2)
-          _ = assert(fTypeVarArr.length == tTypeVarArr.length, s"Both from and to premise matching type vars must either have index or not: got ${fTypeVarStr} and ${tTypeVarStr}")
-          _ = assert(fTypeVarArr(0) == tTypeVarArr(0), s"Both from and to premise must share the same type vars minus index: got ${fTypeVarStr} and ${tTypeVarStr}")
-          if fTypeVarArr.length > 1
-        yield
-          assert(fTypeVarArr.length == 2, s"Only one level of indexes supported: $fTypeVarArr")
-          assert(fTypeVarArr(1) == fromIdxStr, s"From premise type var indexes must match term var indexes: got ${fTypeVarArr(1)}, expected $fromIdxStr")
-          assert(tTypeVarArr(1) == toIdxStr, s"To premise type var indexes must match term var indexes: got ${tTypeVarArr(1)}, expected $toIdxStr")
-          fTypeVarArr(0)
-    }
 
   def typecheck(
     tsDecl: TypeSystemDecl,

--- a/src/main/scala/tyes/interpreter/TyesInterpreter.scala
+++ b/src/main/scala/tyes/interpreter/TyesInterpreter.scala
@@ -45,8 +45,8 @@ object TyesInterpreter:
               val premEnvMatch = EnvironmentMatch(allVarSubst, typeVarEnv, envVarSubst)
               typecheck(tsDecl, judg, premEnvMatch, refinedMetaEnv, allTermSubst)
             case (Some(typeVarEnv), JudgementRange(from, to)) =>
-              val Judgement(fromEnv, HasType(Term.Variable(fromVar), fromTyp)) = from: @unchecked
-              val Judgement(toEnv, HasType(Term.Variable(toVar), toTyp)) = to: @unchecked
+              val HasType(Term.Variable(fromVar), _) = from.assertion: @unchecked
+              val HasType(Term.Variable(toVar), _) = to.assertion: @unchecked
 
               val Some((fromIdent, fromIdxStr)) = extractIndex(fromVar): @unchecked
               val Some((toIdent, toIdxStr)) = extractIndex(toVar): @unchecked

--- a/src/main/scala/tyes/model/Term.scala
+++ b/src/main/scala/tyes/model/Term.scala
@@ -6,10 +6,8 @@ enum Term extends terms.TermOps[Term, Any](TermBuilder):
   case Function(name: String, args: Term*)
   case Type(typ: tyes.model.Type)
 
-  private def ifBothTypes[B](otherTerm: Term, default: => B)(fn: (tyes.model.Type, tyes.model.Type) => B): Option[B] = (this, otherTerm) match {
+  private def ifBothTypes[B](otherTerm: Term)(fn: (tyes.model.Type, tyes.model.Type) => B): Option[B] = (this, otherTerm) match {
     case (Term.Type(thisType), Term.Type(otherType)) => Some(fn(thisType, otherType))
-    case (Term.Type(_), _) => Some(default)
-    case (_, Term.Type(_)) => Some(default)
     case _ => None
   }
 
@@ -19,14 +17,14 @@ enum Term extends terms.TermOps[Term, Any](TermBuilder):
   }
 
   override def matches(otherTerm: Term): Option[Map[String, Term]] = 
-    ifBothTypes(otherTerm, None) { (thisType, otherType) =>
+    ifBothTypes(otherTerm) { (thisType, otherType) =>
       thisType.matches(otherType).map(_.mapValues(Term.Type.apply).toMap)
     }.getOrElse { 
       super.matches(otherTerm) 
     }
 
   override def overlaps(otherTerm: Term): Boolean = 
-    ifBothTypes(otherTerm, false) { 
+    ifBothTypes(otherTerm) { 
       _.overlaps(_) 
     }.getOrElse { 
       super.overlaps(otherTerm) 
@@ -43,7 +41,7 @@ enum Term extends terms.TermOps[Term, Any](TermBuilder):
     }
 
   override def unifies(otherTerm: Term): Option[Map[String, Term]] =
-    ifBothTypes(otherTerm, None) { (thisType, otherType) =>
+    ifBothTypes(otherTerm) { (thisType, otherType) =>
       thisType.unifies(otherType).map(_.mapValues(Term.Type.apply).toMap)
     }.getOrElse { 
       super.unifies(otherTerm) 

--- a/src/main/scala/tyes/model/TyesLanguage.scala
+++ b/src/main/scala/tyes/model/TyesLanguage.scala
@@ -3,7 +3,9 @@ package tyes.model
 sealed abstract class Assertion
 case class HasType(term: Term, typ: Type) extends Assertion
 
-case class Judgement(env: Environment, assertion: Assertion)
+sealed abstract class Premise
+case class Judgement(env: Environment, assertion: Assertion) extends Premise
+case class JudgementRange(from: Judgement, to: Judgement) extends Premise
 
-case class RuleDecl(name: Option[String], premises: Seq[Judgement], conclusion: Judgement)
+case class RuleDecl(name: Option[String], premises: Seq[Premise], conclusion: Judgement)
 case class TypeSystemDecl(name: Option[String], rules: Seq[RuleDecl])

--- a/src/main/scala/tyes/model/TyesLanguageExtensions.scala
+++ b/src/main/scala/tyes/model/TyesLanguageExtensions.scala
@@ -6,16 +6,6 @@ object TyesLanguageExtensions:
   
   extension (metaBinding: Binding)
 
-    def replaceIndex(oldIdxStr: String, newIdxStr: String): Binding = metaBinding match {
-      case Binding.BindName(name, typ) => Binding.BindName(name, typ.replaceIndex(oldIdxStr, newIdxStr))
-      case Binding.BindVariable(rawName, typ) =>
-        val replacedTyp = typ.replaceIndex(oldIdxStr, newIdxStr)
-        extractIndex(rawName) match {
-          case Some((name, `oldIdxStr`)) => Binding.BindVariable(indexedVar(name, newIdxStr), replacedTyp)
-          case _ => Binding.BindVariable(rawName, replacedTyp)
-        }
-    }
-
     def matches(entry: (String, Type)): Option[(Map[String, String], Map[String, Type])] = 
       val (entryName, entryTyp) = entry
       metaBinding match {
@@ -102,14 +92,6 @@ object TyesLanguageExtensions:
         } 
     }
 
-    def replaceIndex(oldIdxStr: String, newIdxStr: String): EnvironmentPart = envPart match {
-      case EnvironmentPart.Bindings(bindings) => EnvironmentPart.Bindings(bindings.map(_.replaceIndex(oldIdxStr, newIdxStr)))
-      case EnvironmentPart.Variable(envVarName) => extractIndex(envVarName) match {
-        case Some((name, `oldIdxStr`)) => EnvironmentPart.Variable(indexedVar(name, newIdxStr))
-        case _ => envPart
-      }
-    }
-
     def toConcrete: Option[Map[String, Type]] = envPart match {
       case EnvironmentPart.Bindings(bindings) => 
         bindings.foldLeft(Option(Map[String, Type]())) { (envOpt, binding) =>
@@ -131,9 +113,6 @@ object TyesLanguageExtensions:
     }
 
   extension (metaEnv: Environment)
-
-    def replaceIndex(oldIdxStr: String, newIdxStr: String): Environment =
-      Environment(metaEnv.parts.map(_.replaceIndex(oldIdxStr, newIdxStr)))
 
     def matches(env: Map[String, Type]): Option[EnvironmentMatch] =
       val remainingEnvVars = metaEnv.envVariables
@@ -166,16 +145,6 @@ object TyesLanguageExtensions:
 
   extension (term: Term)
 
-    def replaceIndex(oldIdxStr: String, newIdxStr: String): Term = term match {
-      case Term.Constant(_) => term
-      case Term.Variable(rawName) => extractIndex(rawName) match {
-        case Some((name, `oldIdxStr`)) => Term.Variable(indexedVar(name, newIdxStr))
-        case _ => term
-      }
-      case Term.Function(name, args*) => Term.Function(name, args.map(_.replaceIndex(oldIdxStr, newIdxStr))*)
-      case Term.Type(typ) => Term.Type(typ.replaceIndex(oldIdxStr, newIdxStr))
-    }
-
     def typeVariables: Set[String] = types.flatMap(_.variables)
 
     def termVariables: Iterable[Term.Variable | Type.Variable] = term match {
@@ -194,13 +163,6 @@ object TyesLanguageExtensions:
 
   extension (asrt: Assertion)
 
-    def replaceIndex(oldIdxStr: String, newIdxStr: String): Assertion = asrt match {
-      case HasType(term, typ) => HasType(
-        term.replaceIndex(oldIdxStr, newIdxStr),
-        typ.replaceIndex(oldIdxStr, newIdxStr)
-      )
-    }
-
     def typeVariables: Set[String] = types.flatMap(_.variables)
     
     def termVariables: Set[String] = asrt match {
@@ -210,13 +172,6 @@ object TyesLanguageExtensions:
     def types: Set[Type] = Set(asrt match {
       case HasType(term, typ) => typ
     })
-
-  extension (judg: Judgement)
-
-    def replaceIndex(oldIdxStr: String, newIdxStr: String): Judgement = Judgement(
-      judg.env.replaceIndex(oldIdxStr, newIdxStr),
-      judg.assertion.replaceIndex(oldIdxStr, newIdxStr)
-    )
 
   extension (prem: Premise)
 
@@ -253,15 +208,6 @@ object TyesLanguageExtensions:
       yield t).toSet
   
   extension (typ: Type)
-
-    def replaceIndex(oldIdxStr: String, newIdxStr: String): Type = typ match {
-      case Type.Named(name) => typ
-      case Type.Variable(rawName) => extractIndex(rawName) match {
-        case Some((name, `oldIdxStr`)) => Type.Variable(indexedVar(name, newIdxStr))
-        case _ => Type.Variable(rawName)
-      }
-      case Type.Composite(name, args*) => Type.Composite(name, args.map(_.replaceIndex(oldIdxStr, newIdxStr))*)
-    }
 
     def typeVariables: Iterable[Type.Variable] = typ match {
       case Type.Named(_) => Set.empty

--- a/src/main/scala/tyes/model/TyesLanguageExtensions.scala
+++ b/src/main/scala/tyes/model/TyesLanguageExtensions.scala
@@ -25,6 +25,12 @@ object TyesLanguageExtensions:
           Binding.BindVariable(name, typ.substitute(typeVarSubst))
     }
 
+    def remap(bindingVarSubst: Map[String, String]): Binding = metaBinding match {
+      case Binding.BindVariable(name, typ) if bindingVarSubst.contains(name) =>
+        Binding.BindVariable(bindingVarSubst(name), typ) 
+      case _ => metaBinding
+    }
+
     def toConcrete: Option[(String, Type)] = metaBinding match {
       case Binding.BindName(name, typ) if typ.isGround => Some(name -> typ)
       case _ => None
@@ -90,6 +96,11 @@ object TyesLanguageExtensions:
         } 
     }
 
+    def remap(bindingVarSubst: Map[String, String]): EnvironmentPart = envPart match {
+      case EnvironmentPart.Bindings(bindings) => EnvironmentPart.Bindings(bindings.map(_.remap(bindingVarSubst)))
+      case _ => envPart
+    }
+
     def toConcrete: Option[Map[String, Type]] = envPart match {
       case EnvironmentPart.Bindings(bindings) => 
         bindings.foldLeft(Option(Map[String, Type]())) { (envOpt, binding) =>
@@ -127,6 +138,9 @@ object TyesLanguageExtensions:
 
     def substitute(envMatch: EnvironmentMatch): Environment =
       Environment(metaEnv.parts.map(_.substitute(envMatch)))
+
+    def remap(bindingVarSubst: Map[String, String]): Environment =
+      Environment(metaEnv.parts.map(_.remap(bindingVarSubst)))
 
     def toConcrete: Option[Map[String, Type]] =
       metaEnv.parts.map(_.toConcrete).foldLeft(Option(Map[String, Type]())) { (prevEnvOpt, currEnvOpt) =>

--- a/src/main/scala/tyes/model/TyesLanguageExtensions.scala
+++ b/src/main/scala/tyes/model/TyesLanguageExtensions.scala
@@ -164,13 +164,22 @@ object TyesLanguageExtensions:
       case HasType(term, typ) => typ
     })
 
-  extension (judg: Judgement)
+  extension (prem: Premise)
 
-    def typeVariables: Set[String] = judg.types.flatMap(_.variables)
+    def typeVariables: Set[String] = prem match {
+      case judg: Judgement => judg.types.flatMap(_.variables)
+      case JudgementRange(from, to) => from.typeVariables ++ to.typeVariables
+    }
 
-    def termVariables: Set[String] = judg.assertion.termVariables ++ judg.env.termVariables
+    def termVariables: Set[String] = prem match {
+      case judg: Judgement => judg.assertion.termVariables ++ judg.env.termVariables
+      case JudgementRange(from, to) => from.termVariables ++ to.termVariables
+    }
 
-    def types: Set[Type] = judg.assertion.types ++ judg.env.types
+    def types: Set[Type] = prem match {
+      case judg: Judgement => judg.assertion.types ++ judg.env.types
+      case JudgementRange(from, to) => from.types ++ to.types
+    }
 
   extension (ruleDecl: RuleDecl)
 

--- a/src/main/scala/tyes/model/TyesParser.scala
+++ b/src/main/scala/tyes/model/TyesParser.scala
@@ -9,22 +9,27 @@ trait TyesParser(buildTermLanguageParser: TyesTermLanguageBindings => Parser[Ter
   // All variables and declaration names: int, Lambda, e1
   def genericIdent = raw"[a-zA-Z][a-zA-Z\d_']*".r.filter(id => !keywords.contains(id))
   
-  // Generic meta variables: e, e1, e'
-  def metaIdent = raw"[a-z](\d+|'+)?".r
+  // Generic meta variables: e, e1, e', e_1, e_n
+  def metaIdent = raw"[a-z](\d+|'+|(_(\d+|[a-z])))?".r
 
-  // Meta variables conventioned to match (synctatic) variables: x, y', z2
-  def metaVarIdent = raw"[f-hx-z](\d+|'+)?".r
+  // Meta variables conventioned to match (synctatic) variables: x, y', z2, z_i
+  def metaVarIdent = raw"[f-hx-z](\d+|'+|(_(\d+|[a-z])))?".r
   
   // Names: 
   def declIdent = genericIdent.filter(id => !metaIdent.matches(id))
 
   def typesystem = "typesystem" ~> declIdent.? ~ rule.+ ^^ { case nameOpt ~ rules => TypeSystemDecl(nameOpt, rules) }
   
-  def rule = ("rule" ~> declIdent.?) ~ ("infers" ~> judgement) ~ ("if" ~> rep1sep(judgement, "and")).? ^^ { 
+  def rule = ("rule" ~> declIdent.?) ~ ("infers" ~> judgement) ~ ("if" ~> rep1sep(premise, "and")).? ^^ { 
     case nameOpt ~ concl ~ premisesOpt  => RuleDecl(nameOpt, premisesOpt.getOrElse(Seq()), concl) 
   }
   
   def assertion = term ~ (":" ~> tpe) ^^ { case term ~ tpe => HasType(term, tpe) }
+
+  def premise: Parser[Premise] = judgement ~ ("and" ~ "..." ~ "and" ~> judgement).? ^^ {
+    case judg ~ None => judg
+    case fromJudg ~ Some(toJudg) => JudgementRange(fromJudg, toJudg)
+  }
   
   def judgement = assertion ~ ("under" ~> environment).? ^^ { case assert ~ envOpt => 
     val env = envOpt.getOrElse(Environment(Seq()))
@@ -50,7 +55,7 @@ trait TyesParser(buildTermLanguageParser: TyesTermLanguageBindings => Parser[Ter
     then Term.Variable(ident)
     else Term.Constant(ident)
   
-  def term = buildTermLanguageParser(new TyesTermLanguageBindings {
+  def term: Parser[Term] = buildTermLanguageParser(new TyesTermLanguageBindings {
     def metaTermVariableParser = metaTermVariable
     def identTermParser(ident: String) = Parsers.success(newIdentifierTerm(ident))
     def typeParser = tpe

--- a/src/main/scala/tyes/model/indexes.scala
+++ b/src/main/scala/tyes/model/indexes.scala
@@ -1,0 +1,14 @@
+package tyes.model
+
+object indexes:
+
+  private val INDEX_SEP = "_"
+
+  def extractIndex(rawVarName: String): Option[(String, String)] =
+    rawVarName.split(INDEX_SEP, 2) match {
+      case Array(varName, idxStr) => Some((varName, idxStr))
+      case _ => None
+    }
+
+  def indexedVar(varName: String, idxStr: String): String = varName + INDEX_SEP + idxStr
+  

--- a/src/main/scala/tyes/model/indexes.scala
+++ b/src/main/scala/tyes/model/indexes.scala
@@ -11,4 +11,70 @@ object indexes:
     }
 
   def indexedVar(varName: String, idxStr: String): String = varName + INDEX_SEP + idxStr
-  
+
+  extension (metaBinding: Binding)
+
+    def replaceIndex(oldIdxStr: String, newIdxStr: String): Binding = metaBinding match {
+      case Binding.BindName(name, typ) => Binding.BindName(name, typ.replaceIndex(oldIdxStr, newIdxStr))
+      case Binding.BindVariable(rawName, typ) =>
+        val replacedTyp = typ.replaceIndex(oldIdxStr, newIdxStr)
+        extractIndex(rawName) match {
+          case Some((name, `oldIdxStr`)) => Binding.BindVariable(indexedVar(name, newIdxStr), replacedTyp)
+          case _ => Binding.BindVariable(rawName, replacedTyp)
+        }
+    }
+
+  extension (envPart: EnvironmentPart)
+
+    def replaceIndex(oldIdxStr: String, newIdxStr: String): EnvironmentPart = envPart match {
+      case EnvironmentPart.Bindings(bindings) => EnvironmentPart.Bindings(bindings.map(_.replaceIndex(oldIdxStr, newIdxStr)))
+      case EnvironmentPart.Variable(envVarName) => extractIndex(envVarName) match {
+        case Some((name, `oldIdxStr`)) => EnvironmentPart.Variable(indexedVar(name, newIdxStr))
+        case _ => envPart
+      }
+    }
+
+  extension (metaEnv: Environment)
+
+    def replaceIndex(oldIdxStr: String, newIdxStr: String): Environment =
+      Environment(metaEnv.parts.map(_.replaceIndex(oldIdxStr, newIdxStr)))
+
+  extension (term: Term)
+
+    def replaceIndex(oldIdxStr: String, newIdxStr: String): Term = term match {
+      case Term.Constant(_) => term
+      case Term.Variable(rawName) => extractIndex(rawName) match {
+        case Some((name, `oldIdxStr`)) => Term.Variable(indexedVar(name, newIdxStr))
+        case _ => term
+      }
+      case Term.Function(name, args*) => Term.Function(name, args.map(_.replaceIndex(oldIdxStr, newIdxStr))*)
+      case Term.Type(typ) => Term.Type(typ.replaceIndex(oldIdxStr, newIdxStr))
+    }
+
+  extension (asrt: Assertion)
+
+    def replaceIndex(oldIdxStr: String, newIdxStr: String): Assertion = asrt match {
+      case HasType(term, typ) => HasType(
+        term.replaceIndex(oldIdxStr, newIdxStr),
+        typ.replaceIndex(oldIdxStr, newIdxStr)
+      )
+    }
+
+  extension (judg: Judgement)
+
+    def replaceIndex(oldIdxStr: String, newIdxStr: String): Judgement = Judgement(
+      judg.env.replaceIndex(oldIdxStr, newIdxStr),
+      judg.assertion.replaceIndex(oldIdxStr, newIdxStr)
+    )
+
+  extension (typ: Type)
+
+    def replaceIndex(oldIdxStr: String, newIdxStr: String): Type = typ match {
+      case Type.Named(name) => typ
+      case Type.Variable(rawName) => extractIndex(rawName) match {
+        case Some((name, `oldIdxStr`)) => Type.Variable(indexedVar(name, newIdxStr))
+        case _ => Type.Variable(rawName)
+      }
+      case Type.Composite(name, args*) => Type.Composite(name, args.map(_.replaceIndex(oldIdxStr, newIdxStr))*)
+    }
+

--- a/src/main/scala/tyes/model/indexes.scala
+++ b/src/main/scala/tyes/model/indexes.scala
@@ -10,6 +10,22 @@ object indexes:
       case _ => None
     }
 
+  def extractIntIndex(rawVarName: String): Option[(String, Int)] =
+    extractIndex(rawVarName) match {
+      case Some((varName, idxStr)) => idxStr.toIntOption.map((varName, _))
+      case _ => None
+    }
+
+  def extractRangeVariable(from: Judgement, to: Judgement): (String, Range) =
+    val HasType(Term.Variable(fromVar), _) = from.assertion: @unchecked
+    val HasType(Term.Variable(toVar), _) = to.assertion: @unchecked
+
+    val Some((fromIdent, fromIdx)) = extractIntIndex(fromVar): @unchecked
+    val Some((toIdent, toIdxStr)) = extractIndex(toVar): @unchecked
+
+    val toIdx = toIdxStr.toIntOption.getOrElse(Int.MaxValue)
+    (fromIdent, Range.inclusive(fromIdx, toIdx))
+
   def indexedVar(varName: String, idxStr: String): String = varName + INDEX_SEP + idxStr
 
   extension (metaBinding: Binding)

--- a/src/main/scala/tyes/model/scope.scala
+++ b/src/main/scala/tyes/model/scope.scala
@@ -1,0 +1,33 @@
+package tyes.model
+
+import tyes.model.indexes.*
+import tyes.model.TyesLanguageExtensions.*
+
+object scope:
+
+  extension (premise: Premise)
+
+    def bindsTypeVariableInEnv(varName: String): Boolean = premise match {
+      case Judgement(env, _) => env.typeVariables.contains(varName)
+      case JudgementRange(from, to) =>
+        val (_, idxRange) = extractRangeVariable(from, to)
+        extractIntIndex(varName) match {
+          case Some((rootVarName, idx)) =>
+            idxRange.contains(idx)
+            && from.bindsTypeVariableInEnv(indexedVar(rootVarName, idxRange.start.toString))
+          
+          case _ => from.bindsTypeVariableInEnv(varName) || to.bindsTypeVariableInEnv(varName)
+        }
+    }
+
+    def bindsTypeVariableInTerm(varName: String): Boolean = premise match {
+      case Judgement(_, term) => term.typeVariables.contains(varName)
+      case JudgementRange(from, to) =>
+        val (_, idxRange) = extractRangeVariable(from, to)
+        extractIntIndex(varName) match {
+          case Some((rootVarName, idx)) =>
+            idxRange.contains(idx)
+            && from.bindsTypeVariableInTerm(indexedVar(rootVarName, idxRange.start.toString))
+          case _ => from.bindsTypeVariableInTerm(varName) || to.bindsTypeVariableInTerm(varName)
+        }
+    }

--- a/src/main/scala/tyes/runtime/TypeSystem.scala
+++ b/src/main/scala/tyes/runtime/TypeSystem.scala
@@ -25,6 +25,13 @@ trait TypeSystem[E[_]]:
       .map(Right.apply)
       .getOrElse(TypeError.noTypeDeclared(parentExp))
 
+  extension (exp: E[T])
+
+    protected def expecting[TargetT <: E[T]](using ct: ClassTag[TargetT]): Either[String, TargetT] =
+      ct.unapply(exp)
+        .map(Right.apply)
+        .getOrElse(TypeError.noTypeFor(exp))
+
   extension (resT: Result[T])
 
     protected def expecting[TargetT <: T](expected: TargetT): Result[TargetT] = resT.flatMap(t =>
@@ -35,8 +42,7 @@ trait TypeSystem[E[_]]:
     )
 
     protected def expecting[TargetT <: T](using ct: ClassTag[TargetT]) = resT.flatMap(t =>
-      ct.unapply(t) match {
-        case Some(castT) => Right(castT)
-        case None => TypeError.unexpectedType(t, ct.runtimeClass)
-      }
+      ct.unapply(t)
+        .map(Right.apply)
+        .getOrElse(TypeError.unexpectedType(t, ct.runtimeClass))
     )

--- a/src/test/scala/tyes/compiler/TargetCodeEnvTests.scala
+++ b/src/test/scala/tyes/compiler/TargetCodeEnvTests.scala
@@ -2,6 +2,7 @@ package tyes.compiler
 
 import org.scalatest.*
 import funspec.*
+import tyes.model.indexes.*
 import tyes.model.Term
 import tyes.compiler.target.TargetCodeNode
 
@@ -79,6 +80,23 @@ class TargetCodeEnvTests extends AnyFunSpec:
 
       }
 
+      describe("can retrieve all indexes with a common root variable") {
+
+        it("returning none if the variable is never indexed") {
+          assert(env.getIndexes(varA.name).isEmpty)
+        }
+
+        it("returning all integer indexes if the variable is indexed") {
+          val rootVarName = "t"
+          
+          for idxStr <- Seq("1", "3", "i") do
+            env.requestIdentifier(Term.Variable(indexedVar(rootVarName, idxStr)))
+
+          assert(env.getIndexes(rootVarName) == Set(1, 3)) 
+        }
+
+      }
+
     }
 
     describe("with a parent") {
@@ -105,6 +123,13 @@ class TargetCodeEnvTests extends AnyFunSpec:
         intercept [NoSuchElementException] {
           parentEnv(localAId)
         }
+      }
+
+      it("includes parent variable indexes") {
+        val rootVarName = "t"
+        parentEnv.requestIdentifier(Term.Variable(indexedVar(rootVarName, "2")))
+        env.requestIdentifier(Term.Variable(indexedVar(rootVarName, "5")))
+        assert(env.getIndexes(rootVarName) == Set(2, 5))
       }
 
     }

--- a/src/vscode-ext/syntaxes/tyes.tmLanguage.json
+++ b/src/vscode-ext/syntaxes/tyes.tmLanguage.json
@@ -19,7 +19,7 @@
     "meta-variables": {
       "patterns": [{
         "name": "variable.name.meta-var.tyes",
-        "match": "\\b[a-z](\\d+|'+)?\\b"
+        "match": "\\b[a-z](\\d+|'+|(_(\\d+|[a-z])))?\\b"
       }]
     }
   },


### PR DESCRIPTION
This PR adds support for "premise ranges", using the following syntax:
```diff
- premise ::= judgement
+ premise ::= judgement ("and" "..." "and" judgement)?
```

At this stage they can be used to express these (admittedly dummy) examples in TyES, which expand during interpretation and compilation in a macro-like fashion.
```
rule infers e_1 + e_2 + e_3 + e_4 : t
  if e_1 : t
  ...
  if e_n : t
```

The end-goal is to eventually be able to write typing rules for list literals, record literals, etc. informally. Supporting ranges of terms in the conclusion of a rule is the following step towards that goal.

For the time being indexes are modeled in ad-hoc fashion, looking for variables with name `<root>_<index>` as an implementation compromise. The goal is to later model indexed variable terms, for which I did an initial exploration in https://github.com/pdferreira/tyes/commit/6b83cc5ff44c38d533d560af30b7b61f90c97171.

Aside from bugfixing, additional improvements done on this PR:
* Extended tyer and tyec with a `-skipValidation` flag to facilitate development of new features without implementing their validation upfront.
* Command line arguments to tyer and tyec can now be separated by any number of spaces