### PR TITLE
Add support for record literals

### DIFF
--- a/samples/in/LiteralRecords.tye
+++ b/samples/in/LiteralRecords.tye
@@ -1,0 +1,10 @@
+typesystem LiteralRecords
+
+  rule infers { } : rec
+
+  rule infers { x = e1, y = e2 } : t1 -> t2 -> rec
+    if e1 : t1
+    and e2 : t2
+
+  rule infers { content = e } : t -> ref
+    if e : t

--- a/samples/in/RecursiveRecords.tye
+++ b/samples/in/RecursiveRecords.tye
@@ -2,6 +2,6 @@ typesystem RecursiveRecords
 
   rule infers { } : rec
 
-  rule infers { l = e | r } : rec
+  rule infers { f = e | r } : rec
     if e : t
     and r : rec

--- a/samples/in/RecursiveRecords.tye
+++ b/samples/in/RecursiveRecords.tye
@@ -1,0 +1,7 @@
+typesystem RecursiveRecords
+
+  rule infers { } : rec
+
+  rule infers { l = e | r } : rec
+    if e : t
+    and r : rec

--- a/samples/in/Sequence_v2.tye
+++ b/samples/in/Sequence_v2.tye
@@ -16,3 +16,8 @@ typesystem SequenceV2
     and ...
     and e_n : t_n
     and b : t2
+
+  rule infers { l_1 = e_1, ..., l_n = e_n } : t -> rec
+    if e_1 : t
+    and ...
+    and e_n : t

--- a/samples/in/Sequence_v2.tye
+++ b/samples/in/Sequence_v2.tye
@@ -17,7 +17,7 @@ typesystem SequenceV2
     and e_n : t_n
     and b : t2
 
-  rule infers { l_1 = e_1, ..., l_n = e_n } : t -> rec
+  rule infers { f_1 = e_1, ..., f_n = e_n } : t -> rec
     if e_1 : t
     and ...
     and e_n : t

--- a/samples/out/new/src/LiteralRecordsTypeSystem.scala
+++ b/samples/out/new/src/LiteralRecordsTypeSystem.scala
@@ -1,0 +1,32 @@
+import tyes.runtime.*
+import example.*
+
+class LiteralRecordsTypeSystem extends TypeSystem[LExpression]:
+  type T = Type
+
+  enum Type extends tyes.runtime.Type:
+    case Rec
+    case Ref
+    case $FunType(t1: Type, t2: Type) extends Type, tyes.runtime.CompositeType(t1, t2)
+
+  def typecheck(exp: LExpression[Type], env: Environment[Type]): Either[String, Type] = exp match {
+    case LEmptyRecord => Right(Type.Rec)
+    case LRecord(x, e1, e3) => 
+      if e3.isInstanceOf[LRecord[?]] then
+        for
+          t1 <- typecheck(e1, env)
+          LRecord(_, e2, ec) = e3: @unchecked
+          t2 <- typecheck(e2, env)
+          _ <- checkIf(ec == LEmptyRecord, TypeError.noTypeFor(ec))
+        yield
+          Type.$FunType(t1, Type.$FunType(t2, Type.Rec))
+      else if e3 == LEmptyRecord && x == "content" then
+        for
+          t <- typecheck(e1, env)
+        yield
+          Type.$FunType(t, Type.Ref)
+      else
+        TypeError.noTypeFor(exp)
+
+    case _ => TypeError.noTypeFor(exp)
+  }

--- a/samples/out/new/src/RecursiveRecordsTypeSystem.scala
+++ b/samples/out/new/src/RecursiveRecordsTypeSystem.scala
@@ -1,0 +1,20 @@
+import tyes.runtime.*
+import example.*
+
+class RecursiveRecordsTypeSystem extends TypeSystem[LExpression]:
+  type T = Type
+
+  enum Type extends tyes.runtime.Type:
+    case Rec
+
+  def typecheck(exp: LExpression[Type], env: Environment[Type]): Either[String, Type] = exp match {
+    case LEmptyRecord => Right(Type.Rec)
+    case LRecord(l, e, r) => 
+      for
+        _ <- typecheck(e, env)
+        _ <- typecheck(r, env).expecting(Type.Rec)
+      yield
+        Type.Rec
+
+    case _ => TypeError.noTypeFor(exp)
+  }

--- a/samples/out/new/src/RecursiveRecordsTypeSystem.scala
+++ b/samples/out/new/src/RecursiveRecordsTypeSystem.scala
@@ -9,7 +9,7 @@ class RecursiveRecordsTypeSystem extends TypeSystem[LExpression]:
 
   def typecheck(exp: LExpression[Type], env: Environment[Type]): Either[String, Type] = exp match {
     case LEmptyRecord => Right(Type.Rec)
-    case LRecord(l, e, r) => 
+    case LRecord(f, e, r) => 
       for
         _ <- typecheck(e, env)
         _ <- typecheck(r, env).expecting(Type.Rec)

--- a/samples/out/new/src/SequenceV2TypeSystem.scala
+++ b/samples/out/new/src/SequenceV2TypeSystem.scala
@@ -7,6 +7,7 @@ class SequenceV2TypeSystem extends TypeSystem[LExpression]:
   enum Type extends tyes.runtime.Type:
     case List
     case One
+    case Rec
     case Two
     case $FunType(t1: Type, t2: Type) extends Type, tyes.runtime.CompositeType(t1, t2)
 
@@ -30,6 +31,16 @@ class SequenceV2TypeSystem extends TypeSystem[LExpression]:
       else
         TypeError.noTypeFor(exp)
 
+    case LRecordRange((ls, es, e3)) => 
+      if e3 == LEmptyRecord then
+        for
+          t <- typecheck(es(0), env)
+          _ <- (1 until es.size).foldRange(Seq(t))(i => typecheck(es(i), env).expecting(t))
+        yield
+          Type.$FunType(t, Type.Rec)
+      else
+        TypeError.noTypeFor(exp)
+
     case LLetRange((x, _ts, es, b)) => 
       for
         t2 <- typecheck(b, env)
@@ -46,3 +57,6 @@ class SequenceV2TypeSystem extends TypeSystem[LExpression]:
 
   object LLetRange:
     def unapply(exp: LExpression[Type]) = exp.extractRangeR[LLet[Type]]
+
+  object LRecordRange:
+    def unapply(exp: LExpression[Type]) = exp.extractRangeR[LRecord[Type]]

--- a/samples/out/new/src/SequenceV2TypeSystem.scala
+++ b/samples/out/new/src/SequenceV2TypeSystem.scala
@@ -31,7 +31,7 @@ class SequenceV2TypeSystem extends TypeSystem[LExpression]:
       else
         TypeError.noTypeFor(exp)
 
-    case LRecordRange((ls, es, e3)) => 
+    case LRecordRange((fs, es, e3)) => 
       if e3 == LEmptyRecord then
         for
           t <- typecheck(es(0), env)

--- a/src/main/scala/example/LExpressionLanguage.scala
+++ b/src/main/scala/example/LExpressionLanguage.scala
@@ -9,3 +9,5 @@ case class LFun[TType](argName: String, argType: Option[TType], bodyExp: LExpres
 case class LApp[TType](funExp: LExpression[TType], argExp: LExpression[TType]) extends LExpression[TType]
 case object LNil extends LExpression[Nothing]
 case class LList[TType](head: LExpression[TType], tail: LExpression[TType]) extends LExpression[TType]
+case object LEmptyRecord extends LExpression[Nothing]
+case class LRecord[TType](label: String, exp: LExpression[TType], rest: LExpression[TType]) extends LExpression[TType]

--- a/src/main/scala/example/LExpressionParser.scala
+++ b/src/main/scala/example/LExpressionParser.scala
@@ -16,7 +16,11 @@ class LExpressionParser[TType] extends RegexParsers:
     elems => elems.foldRight(LNil: LExpression[TType]) { (e, l) => LList(e, l) }
   }
 
-  def leaf = ("(" ~> expression <~ ")") | number | variable | list
+  def record = "{" ~> repsep(ident ~ ("=" ~> expression), ",") <~ "}" ^^ {
+    elems => elems.foldRight(LEmptyRecord: LExpression[TType]) { case (label ~ exp, r) => LRecord(label, exp, r) }
+  }
+
+  def leaf = ("(" ~> expression <~ ")") | number | variable | list | record
 
   def app = rep1sep(leaf, "") ^? {
     case exp +: rs => rs.foldLeft(exp) { (left, right) => LApp(left, right) }

--- a/src/main/scala/tyes/cli/LExpressionContextParser.scala
+++ b/src/main/scala/tyes/cli/LExpressionContextParser.scala
@@ -32,11 +32,21 @@ class LExpressionContextParser(bindings: TyesTermLanguageBindings):
     ("|" ~> metaVariable).? ^^ { tail => tail.getOrElse(Term.Function("LNil")) } 
   } <~ "]"
   
+  def record = "{" ~> bindings.repXopR(
+    ident ~ ("=" ~> expression) ^^ { case label ~ exp => Seq(label, exp) },
+    ",",
+    "LRecord",
+    atLeastOne = false
+  ) {
+    ("|" ~> metaVariable).? ^^ { rest => rest.getOrElse(Term.Function("LEmptyRecord")) }
+  } <~ "}"
+
   def leaf = 
     ("(" ~> expression <~ ")") 
     | number 
     | variable
     | list
+    | record
 
   def app = bindings.rep1opL(leaf, "", "LApp")
 

--- a/src/main/scala/tyes/cli/LExpressionExtensions.scala
+++ b/src/main/scala/tyes/cli/LExpressionExtensions.scala
@@ -29,4 +29,12 @@ object LExpressionExtensions:
         case LApp(funExp, argExp) => Term.Function("LApp", funExp.convert, argExp.convert)
         case LNil => Term.Function("LNil")
         case LList(head, tail) => Term.Function("LList", head.convert, tail.convert)
+        case LEmptyRecord => Term.Function("LEmptyRecord")
+        case LRecord(label, exp, rest) =>
+          Term.Function(
+            "LRecord",
+            Term.Constant(label),
+            exp.convert,
+            rest.convert
+          )
     }

--- a/src/main/scala/tyes/compiler/RuleIRGenerator.scala
+++ b/src/main/scala/tyes/compiler/RuleIRGenerator.scala
@@ -65,12 +65,12 @@ class RuleIRGenerator(
 
   case class GenerateOutput(node: IRNode, condition: Option[IRCond])
 
-  def generate(rule: RuleDecl, parentCodeEnv: TargetCodeEnv, overallTemplate: Term): GenerateOutput =
+  def generate(rule: RuleDecl, parentCodeEnv: TargetCodeEnv, constructor: Term): GenerateOutput =
     val HasType(cTerm, cType) = rule.conclusion.assertion: @unchecked
 
     val codeEnv = new TargetCodeEnv(Some(parentCodeEnv))
 
-    val conclusionConds = genConclusionConds(rule.conclusion, codeEnv)
+    val conclusionConds = genConclusionConds(rule.conclusion, codeEnv, constructor)
     val premiseConds = rule.premises.flatMap(p => genPremiseConds(p, codeEnv))
     val conds = conclusionConds ++ premiseConds
 
@@ -82,7 +82,7 @@ class RuleIRGenerator(
         next = result
       )
 
-    val constructorReqs = genConstructorReqs(cTerm)
+    val constructorReqs = genConstructorReqs(cTerm, constructor)
 
     GenerateOutput(
       node = result,
@@ -91,8 +91,7 @@ class RuleIRGenerator(
         .map(_.foldLeft1(IRCond.And.apply))
     )
 
-  private def genConstructorReqs(term: Term): Iterable[IRCond] =
-    val constructor = extractTemplate(term)
+  private def genConstructorReqs(term: Term, constructor: Term): Iterable[IRCond] =
     val constructorReqs = constructor.matches(term)
       .get
       .toSeq
@@ -100,15 +99,14 @@ class RuleIRGenerator(
 
     genRequiredConds(constructorReqs)
 
-  private def genConclusionConds(concl: Judgement, codeEnv: TargetCodeEnv): Seq[IRCond] =
+  private def genConclusionConds(concl: Judgement, codeEnv: TargetCodeEnv, constructor: Term): Seq[IRCond] =
     val HasType(cTerm, _) = concl.assertion: @unchecked
     
     val envConds = envIRGenerator.generateConditions(concl.env, codeEnv)
-    val termConds = genConclusionTermConds(cTerm, codeEnv)
+    val termConds = genConclusionTermConds(cTerm, codeEnv, constructor)
     termConds ++ envConds
 
-  private def genConclusionTermConds(cTerm: Term, codeEnv: TargetCodeEnv): Seq[IRCond] =
-    val constructor = extractTemplate(cTerm)
+  private def genConclusionTermConds(cTerm: Term, codeEnv: TargetCodeEnv, constructor: Term): Seq[IRCond] =
     val termSubst = constructor.matches(cTerm).get
     val typeSubst = termSubst
       .collect({ case (k, Term.Type(typ)) => k -> typ })

--- a/src/main/scala/tyes/compiler/TyesEnvDesugarer.scala
+++ b/src/main/scala/tyes/compiler/TyesEnvDesugarer.scala
@@ -23,11 +23,6 @@ class TyesEnvDesugarer(commonEnvVar: String):
       conclusion = desugar(concl, conclEnvVars.headOption)
     )
 
-  type PremiseMatch[P <: Premise] <: Premise = P match {
-    case Judgement => Judgement
-    case JudgementRange => JudgementRange
-  }
-
   def desugar(prem: Premise, envVarToReplace: Option[String]): PremiseMatch[prem.type]  = prem match {
     case judg: Judgement => judg.copy(env = desugar(judg.env, envVarToReplace))
     case rng: JudgementRange => JudgementRange(

--- a/src/main/scala/tyes/compiler/TypeSystemIRGenerator.scala
+++ b/src/main/scala/tyes/compiler/TypeSystemIRGenerator.scala
@@ -1,5 +1,6 @@
 package tyes.compiler
 
+import scala.collection.mutable
 import tyes.compiler.Orderings.given
 import tyes.compiler.ir.IRNode
 import tyes.compiler.ir.IRError
@@ -65,19 +66,29 @@ class TypeSystemIRGenerator(
   private def generateTypecheckBody(expVar: TCN.Var, rules: Seq[RuleDecl]): TargetCodeNode =
     val defaultCase = TCP.Any -> RuntimeAPIGenerator.genError(IRError.NoType(expVar))
 
-    val ruleCases = rules
-      .groupBy(r => ruleIRGenerator.getTemplate(r))
+    val rulesByMatchingTemplate = mutable.Map[Term, mutable.ListBuffer[RuleDecl]]()
+    for r <- rules do
+      val rTemplate = ruleIRGenerator.getTemplate(r)
+      val groupTemplate = rulesByMatchingTemplate.keys
+        .collectFirst(Function.unlift(k => rTemplate.matches(k).map((k, _))))
+        
+      groupTemplate match {
+        case None => rulesByMatchingTemplate(rTemplate) = mutable.ListBuffer(r)
+        case Some((gTemplate, subst)) => rulesByMatchingTemplate(gTemplate) += r.substitute(subst)
+      }
+
+    val ruleCases = rulesByMatchingTemplate
       .toSeq
-      .sortBy((rTemplate, _) => rTemplate: Term)
-      .map((rTemplate, rs) => generateTypecheckCase(rTemplate, rs))
+      .sortBy({ case (gTemplate, _) => gTemplate: Term })
+      .map({ case (gTemplate, rs) => generateTypecheckCase(gTemplate, rs.toSeq) })
 
     TCN.Match(
       expVar,
       branches = ruleCases :+ defaultCase
     )
 
-  private def generateTypecheckCase(rTemplate: Term, rules: Seq[RuleDecl]): (TargetCodePattern, TargetCodeNode) =
-    val (rTemplateCode, elemVars) = termIRGenerator.generatePattern(rTemplate)
+  private def generateTypecheckCase(gTemplate: Term, rules: Seq[RuleDecl]): (TargetCodePattern, TargetCodeNode) =
+    val (rTemplateCode, elemVars) = termIRGenerator.generatePattern(gTemplate)
     
     val codeEnv = TargetCodeEnv()
     for v <- boundNames(rTemplateCode) do
@@ -88,7 +99,7 @@ class TypeSystemIRGenerator(
       // - if it has a single rule, use its resulting node
       // - otherwise if all have pre-conditions, create a switch node
       .map(rs => 
-        val rIRs = rs.map(r => ruleIRGenerator.generate(r, codeEnv, rTemplate))
+        val rIRs = rs.map(r => ruleIRGenerator.generate(r, codeEnv, gTemplate))
         if rIRs.exists(_.condition.isEmpty) then
           val rulesDesc = rs.zipWithIndex.map((r, idx) => r.name.getOrElse(idx.toString)).mkString(" and ")
           assert(rIRs.length == 1, s"If there're no conditions, expected only a single rule in the group, not $rulesDesc")

--- a/src/main/scala/tyes/interpreter/TyesInterpreter.scala
+++ b/src/main/scala/tyes/interpreter/TyesInterpreter.scala
@@ -43,11 +43,8 @@ object TyesInterpreter:
     case Judgement(metaEnv, HasType(metaTerm, typ)) =>
       metaTerm.matches(term).flatMap { (termSubst) =>
         // replace the vars we already unified in the term
-        // TODO: review assumption that only string constants that are directly unified are variables
-        val termVarSubst = termSubst.collect { case (k, Term.Constant(varName: String)) => k -> varName }
-        val typeVarSubst = termSubst.collect { case (k, Term.Type(t)) => k -> t }
-        val refinedMetaEnv = getSelfOrDefaultIfEmpty(metaEnv, DefaultEnv)
-          .substitute(EnvironmentMatch(termVarSubst, typeVarSubst))
+        val envMatch = EnvironmentMatch.fromTermSubst(termSubst)
+        val refinedMetaEnv = getSelfOrDefaultIfEmpty(metaEnv, DefaultEnv).substitute(envMatch)
 
         // match the conclusion env to the rule to see if it's applicable at all
         refinedMetaEnv.matches(termEnv).flatMap { case m @ EnvironmentMatch(envTermVarSubst, envTypeVarSubst, envVarSubst) =>
@@ -55,8 +52,8 @@ object TyesInterpreter:
           val refinedMetaTerm = metaTerm.substitute(envTermSubst)
 
           // build variable substitutions considering info from term and environment
-          val allVarSubst = envTermVarSubst ++ termVarSubst
-          val allTypeVarSubst = envTypeVarSubst ++ typeVarSubst
+          val allVarSubst = envTermVarSubst ++ envMatch.termVarSubst
+          val allTypeVarSubst = envTypeVarSubst ++ envMatch.typeVarSubst
           val allTermSubst = envTermSubst ++ termSubst
 
           // check all premises hold, while unifying possible type variables

--- a/src/main/scala/tyes/model/TyesLanguageExtensions.scala
+++ b/src/main/scala/tyes/model/TyesLanguageExtensions.scala
@@ -5,7 +5,12 @@ import tyes.model.ranges.*
 import tyes.model.terms.*
 
 object TyesLanguageExtensions:
-  
+
+  type PremiseMatch[P <: Premise] <: Premise = P match {
+    case Judgement => Judgement
+    case JudgementRange => JudgementRange
+  }
+
   extension (metaBinding: Binding)
 
     def matches(entry: (String, Type)): Option[(Map[String, String], Map[String, Type])] = 
@@ -51,6 +56,14 @@ object TyesLanguageExtensions:
     typeVarSubst: Map[String, Type] = Map(),
     envVarSubst: Map[String, Either[String, Map[String, Type]]] = Map()
   )
+
+  object EnvironmentMatch:
+
+    def fromTermSubst(termSubst: Map[String, Term]): EnvironmentMatch =
+      // TODO: review assumption that only string constants that are directly unified are variables
+      val termVarSubst = termSubst.collect { case (k, Term.Constant(varName: String)) => k -> varName }
+      val typeVarSubst = termSubst.collect { case (k, Term.Type(t)) => k -> t }  
+      EnvironmentMatch(termVarSubst, typeVarSubst)
 
   extension (envPart: EnvironmentPart)
 
@@ -169,6 +182,20 @@ object TyesLanguageExtensions:
       case HasType(term, typ) => typ
     })
 
+    def substitute(subst: Map[String, Term]) = asrt match {
+      case HasType(term, typ) => HasType(
+        term.substitute(subst),
+        typ.substitute(subst.collect({ case (k, Term.Type(t)) => k -> t }))
+      )
+    }
+
+  extension (judg: Judgement)
+
+    def substitute(subst: Map[String, Term]): Judgement = Judgement(
+      env = judg.env.substitute(EnvironmentMatch.fromTermSubst(subst)),
+      assertion = judg.assertion.substitute(subst)
+    )
+
   extension (prem: Premise)
 
     private def combineWithoutWildcard(fromVars: Set[String], toVars: Set[String]): Set[String] = {
@@ -205,6 +232,14 @@ object TyesLanguageExtensions:
       case JudgementRange(from, to) => from.types ++ to.types
     }
 
+    def substitute(subst: Map[String, Term]): Premise = prem match {
+      case j: Judgement => j.substitute(subst)
+      case jr: JudgementRange => jr.copy(
+        from = jr.from.substitute(subst),
+        to = jr.to.substitute(subst)
+      )
+    }
+
   extension (ruleDecl: RuleDecl)
 
     def typeVariables: Set[String] = types.flatMap(_.variables)
@@ -212,6 +247,11 @@ object TyesLanguageExtensions:
     def termVariables: Set[String] = ruleDecl.conclusion.termVariables ++ ruleDecl.premises.flatMap(_.termVariables)
 
     def types: Set[Type] = ruleDecl.conclusion.types ++ ruleDecl.premises.flatMap(_.types)
+
+    def substitute(subst: Map[String, Term]): RuleDecl = ruleDecl.copy(
+      premises = ruleDecl.premises.map(_.substitute(subst)),
+      conclusion = ruleDecl.conclusion.substitute(subst)
+    )
 
   extension (tsDecl: TypeSystemDecl)
 

--- a/src/main/scala/tyes/model/TyesParser.scala
+++ b/src/main/scala/tyes/model/TyesParser.scala
@@ -13,7 +13,7 @@ trait TyesParser(buildTermLanguageParser: TyesTermLanguageBindings => Parser[Ter
   def metaIdent = raw"[a-z](\d+|'+|(_(\d+|[a-z])))?".r
 
   // Meta variables conventioned to match (synctatic) variables: x, y', z2, z_i
-  def metaVarIdent = raw"[f-hx-z](\d+|'+|(_(\d+|[a-z])))?".r
+  def metaVarIdent = raw"[f-hlx-z](\d+|'+|(_(\d+|[a-z])))?".r
   
   // Names: 
   def declIdent = genericIdent.filter(id => !metaIdent.matches(id))

--- a/src/main/scala/tyes/model/TyesParser.scala
+++ b/src/main/scala/tyes/model/TyesParser.scala
@@ -13,7 +13,7 @@ trait TyesParser(buildTermLanguageParser: TyesTermLanguageBindings => Parser[Ter
   def metaIdent = raw"[a-z](\d+|'+|(_(\d+|[a-z])))?".r
 
   // Meta variables conventioned to match (synctatic) variables: x, y', z2, z_i
-  def metaVarIdent = raw"[f-hlx-z](\d+|'+|(_(\d+|[a-z])))?".r
+  def metaVarIdent = raw"[f-hx-z](\d+|'+|(_(\d+|[a-z])))?".r
   
   // Names: 
   def declIdent = genericIdent.filter(id => !metaIdent.matches(id))


### PR DESCRIPTION
This PR adds support for record literals in the expression language.

```{ field1 = exp1, ..., fieldN = expN }```